### PR TITLE
ML back-end, workflows, database additions/encoding, and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 # ECNet: scalable, retrainable and deployable machine learning projects for fuel property prediction
 
-[![GitHub version](https://badge.fury.io/gh/tjkessler%2FECNet.svg)](https://badge.fury.io/gh/tjkessler%2FECNet)
+[![GitHub version](https://badge.fury.io/gh/ecrl%2FECNet.svg)](https://badge.fury.io/gh/ecrl%2FECNet)
 [![PyPI version](https://badge.fury.io/py/ecnet.svg)](https://badge.fury.io/py/ecnet)
 [![status](http://joss.theoj.org/papers/f556afbc97e18e1c1294d98e0f7ff99f/status.svg)](http://joss.theoj.org/papers/f556afbc97e18e1c1294d98e0f7ff99f)
-[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/TJKessler/ECNet/master/LICENSE.txt)
+[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/ECRL/ECNet/master/LICENSE.txt)
 [![Documentation Status](https://readthedocs.org/projects/ecnet/badge/?version=latest)](https://ecnet.readthedocs.io/en/latest/?badge=latest)
 [![Build Status](https://dev.azure.com/uml-ecrl/package-management/_apis/build/status/ECRL.ECNet?branchName=master)](https://dev.azure.com/uml-ecrl/package-management/_build/latest?definitionId=1&branchName=master)
 	
-**ECNet** is an open source Python package for creating scalable, retrainable and deployable machine learning projects with a focus on fuel property prediction. An ECNet __project__ is considered a collection of __pools__, where each pool contains a neural network that has been selected from a group of __candidate__ neural networks. Candidates are selected to represent pools based on their ability to optimize certain learning criteria (for example, performing optimially on unseen data). Each pool contributes a prediction derived from input data, and these predictions are averaged to calculate the project's final prediction. Using multiple pools allows a project to learn from a variety of learning and validation sets, which can reduce the project's prediction error. Projects can be saved and reused at a later time allowing additional training and deployable predictive models. 
+**ECNet** is an open source Python package for creating scalable, retrainable and deployable machine learning projects with a focus on fuel property prediction. An ECNet __project__ is considered a collection of __pools__, where each pool contains a neural network that has been selected from a group of __candidate__ neural networks. Candidates are selected to represent pools based on their ability to optimize certain learning criteria (for example, performing optimially on unseen data). Each pool contributes a prediction derived from input data, and these predictions are averaged to calculate the project's final prediction. Using multiple pools allows a project to learn from a variety of learning and validation sets, which can reduce the project's prediction error. Projects can be saved and reused at a later time allowing additional training and deployable predictive models.
 
 [T. Sennott et al.](https://doi.org/10.1115/ICEF2013-19185) have shown that neural networks can be applied to cetane number prediction with relatively little error. ECNet provides scientists an open source tool for predicting key fuel properties of potential next-generation biofuels, reducing the need for costly fuel synthesis and experimentation.
 
@@ -17,7 +17,7 @@
   <img align="center" src="docs/img/workflow_diagram.png" width="50%" height="50%">
 </p>
 
-Using ECNet, [T. Kessler et al.](https://doi.org/10.1016/j.fuel.2017.06.015) have increased the generalizability of neural networks to predict the cetane number for a variety of molecular classes represented in our [cetane number database](https://github.com/TJKessler/ECNet/tree/master/databases), and have increased the accuracy of neural networks for predicting the cetane number of underrepresented molecular classes through targeted database expansion.
+Using ECNet, [T. Kessler et al.](https://doi.org/10.1016/j.fuel.2017.06.015) have increased the generalizability of neural networks to predict the cetane number for a variety of molecular classes represented in our [cetane number database](https://github.com/ECRL/ECNet/tree/master/databases), and have increased the accuracy of neural networks for predicting the cetane number of underrepresented molecular classes through targeted database expansion.
 
 Future plans for ECNet include:
 - distributed candidate training for GPU's
@@ -34,4 +34,4 @@ To contribute to ECNet, make a pull request. Contributions should include tests 
 
 To report problems with the software or feature requests, file an issue. When reporting problems, include information such as error messages, your OS/environment and Python version.
 
-For additional support/questions, contact Travis Kessler (travis.j.kessler@gmail.com), Hernan Gelaf-Romer (hernan_gelafromer@student.uml.edu) and/or John Hunter Mack (Hunter_Mack@uml.edu).
+For additional support/questions, contact Travis Kessler (Travis_Kessler@student.uml.edu) and/or John Hunter Mack (Hunter_Mack@uml.edu).

--- a/ecnet/__init__.py
+++ b/ecnet/__init__.py
@@ -1,2 +1,2 @@
 from ecnet.server import Server
-__version__ = '3.2.3'
+__version__ = '3.3.0'

--- a/ecnet/models/mlp.py
+++ b/ecnet/models/mlp.py
@@ -75,7 +75,7 @@ class MultilayerPerceptron:
     def fit(self, l_x: array, l_y: array, v_x: array=None, v_y: array=None,
             epochs: int=1500, lr: float=0.001, beta_1: float=0.9,
             beta_2: float=0.999, epsilon: float=0.0000001, decay: float=0.0,
-            v: int=0, batch_size: int=32):
+            v: int=0, batch_size: int=32, patience: int=128):
         '''Fits neural network to supplied inputs and targets
         Args:
             l_x (numpy.array): learning input data
@@ -114,7 +114,7 @@ class MultilayerPerceptron:
                 validation_data=(v_x, v_y),
                 callbacks=[EarlyStopping(
                     monitor='val_loss',
-                    patience=250,
+                    patience=patience,
                     verbose=v,
                     mode='min',
                     restore_best_weights=True

--- a/ecnet/models/mlp.py
+++ b/ecnet/models/mlp.py
@@ -89,7 +89,7 @@ class MultilayerPerceptron(Module):
     def fit(self, l_x: array, l_y: array, v_x: array=None, v_y: array=None,
             epochs: int=1500, lr: float=0.001, beta_1: float=0.9,
             beta_2: float=0.999, epsilon: float=0.0000001, decay: float=0.0,
-            v: int=0, batch_size: int=32, patience: int=32) -> list:
+            v: int=0, batch_size: int=32, patience: int=128) -> list:
         '''Fits neural network to supplied inputs and targets
 
         Args:

--- a/ecnet/models/mlp.py
+++ b/ecnet/models/mlp.py
@@ -2,18 +2,19 @@
 # -*- coding: utf-8 -*-
 #
 # ecnet/models/mlp.py
-# v.3.2.3
-# Developed in 2019 by Travis Kessler <travis.j.kessler@gmail.com>
+# v.3.3.0
+# Developed in 2020 by Travis Kessler <travis.j.kessler@gmail.com>
 #
 # Contains the "MultilayerPerceptron" (feed-forward neural network) class
 #
 
+# Stdlib imports
 from os import environ
 from re import compile, IGNORECASE
 
+# 3rd party imports
 from h5py import File
 from numpy import array, string_, zeros
-
 from tensorflow import config, Tensor
 from tensorflow.keras.callbacks import EarlyStopping
 from tensorflow.keras.layers import Dense
@@ -21,6 +22,7 @@ from tensorflow.keras.losses import MeanSquaredError
 from tensorflow.keras.models import Model
 from tensorflow.keras.optimizers import Adam
 
+# ECNet imports
 from ecnet.utils.logging import logger
 
 environ['TF_CPP_MIN_LOG_LEVEL'] = '2'

--- a/ecnet/models/mlp.py
+++ b/ecnet/models/mlp.py
@@ -10,88 +10,73 @@
 
 # Stdlib imports
 from re import compile, IGNORECASE
+from os import devnull, environ
+import sys
 
 # 3rd party imports
-from numpy import arange, array, asarray
-from numpy.random import choice
-from torch import load, relu, save, sigmoid, stack, tensor
-from torch.nn import Linear, Module, MSELoss
-from torch.optim import Adam
+from tensorflow import get_default_graph, logging
+from numpy import array
+stderr = sys.stderr
+sys.stderr = open(devnull, 'w')
+from keras.backend import clear_session, reset_uids
+from keras.callbacks import EarlyStopping
+from keras.layers import Dense
+from keras.losses import mean_squared_error
+from keras.metrics import mae
+from keras.models import load_model, Sequential
+from keras.optimizers import Adam
+sys.stderr = stderr
 
 # ECNet imports
 from ecnet.utils.logging import logger
 
-ECNET_EXT = compile(r'.*\.ecnet', flags=IGNORECASE)
+environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
+logging.set_verbosity(logging.ERROR)
+
+H5_EXT = compile(r'.*\.h5', flags=IGNORECASE)
 
 
-def check_ext(filename: str):
-    '''Ensures the supplied filename has a `.ecnet` extension
+class MultilayerPerceptron:
 
-    Args:
-        filename (str): supplied filename
-    '''
-
-    if ECNET_EXT.match(filename) is None:
-        raise ValueError('Invalid filename/extension, must be `.ecnet`: {}'
-                         .format(filename))
-
-
-class MultilayerPerceptron(Module):
-
-    def __init__(self, filename: str='model.ecnet'):
+    def __init__(self, filename: str='model.h5'):
         '''MultilayerPerceptron object: fits neural network to supplied inputs
         and targets
-
         Args:
-            filename (str): path to model save location (.ecnet extension)
+            filename (str): path to model save location (.h5 extension)
         '''
 
-        super(MultilayerPerceptron, self).__init__()
-        check_ext(filename)
+        if H5_EXT.match(filename) is None:
+            raise ValueError(
+                'Invalid filename/extension, must be `.h5`: {}'.format(
+                    filename
+                )
+            )
         self._filename = filename
-        self._layers = []
+        clear_session()
+        self._model = Sequential(name=filename.lower().replace('.h5', ''))
 
     def add_layer(self, num_neurons: int, activation: str,
                   input_dim: int=None):
         '''Adds a fully-connected layer to the model
-
         Args:
             num_neurons (int): number of neurons for the layer
-            activation (str): activation function for the layer (`sigmoid`,
-                `relu`, `linear`)
+            activation (str): activation function for the layer (see Keras
+                activation function documentation)
             input_dim (int): if not None (input layer), specifies input
                 dimensionality
         '''
 
-        if activation == 'sigmoid' or activation == sigmoid:
-            activation = sigmoid
-        elif activation == 'relu' or activation == relu:
-            activation = relu
-        elif activation == 'linear' or activation is None:
-            activation = None
-        else:
-            raise ValueError('Unknown activation: {}'.format(activation))
-        if input_dim is not None:
-            self._layers.append((
-                input_dim, num_neurons, activation
-            ))
-        else:
-            if len(self._layers) == 0:
-                raise AttributeError('Must include input dimensionality for '
-                                     'first layer')
-            self._layers.append((
-                self._layers[-1][1], num_neurons, activation
-            ))
-        setattr(self, '_l{}'.format(len(self._layers) - 1), Linear(
-            self._layers[-1][0], self._layers[-1][1]
+        self._model.add(Dense(
+            units=num_neurons,
+            activation=activation,
+            input_shape=(input_dim,)
         ))
 
     def fit(self, l_x: array, l_y: array, v_x: array=None, v_y: array=None,
             epochs: int=1500, lr: float=0.001, beta_1: float=0.9,
             beta_2: float=0.999, epsilon: float=0.0000001, decay: float=0.0,
-            v: int=0, batch_size: int=32, patience: int=128) -> list:
+            v: int=0, batch_size: int=32):
         '''Fits neural network to supplied inputs and targets
-
         Args:
             l_x (numpy.array): learning input data
             l_y (numpy.array): learning target data
@@ -108,162 +93,86 @@ class MultilayerPerceptron(Module):
             decay (float): learning rate decay for Adam optimizer
             v (int): verbose training, `0` for no printing, `1` for printing
             batch_size (int): number of learning samples per batch
-            patience (int): if performing periodic validation, will wait this
-                many epochs for a better validation loss; will terminate
-                training if better loss not found
-
-        Returns:
-            list: list of tuples, (train loss, valid loss) at each epoch; if
-                not performing periodic validation, index 1 of tuple is None
         '''
 
-        criterion = MSELoss()
-        optimizer = Adam(
-            self.parameters(),
-            lr,
-            (beta_1, beta_2),
-            epsilon,
-            decay
+        self._model.compile(
+            loss=mean_squared_error,
+            optimizer=Adam(
+                lr=lr,
+                beta_1=beta_1,
+                beta_2=beta_2,
+                epsilon=epsilon,
+                decay=decay
+            ),
+            metrics=[mae]
         )
 
-        losses = []
-        trained_epochs = epochs
-
         if v_x is not None and v_y is not None:
-            best_model_params = self.state_dict()
-            best_valid_loss = None
-            valid_count = 0
-            for e in range(epochs):
-                train_x, train_y = self._batch(l_x, l_y, batch_size)
-                valid_x, valid_y = self._batch(v_x, v_y, batch_size)
-                optimizer.zero_grad()
-                train_output = self(train_x)
-                train_loss = criterion(train_output, train_y)
-                train_loss.backward()
-                optimizer.step()
-                valid_output = self(valid_x)
-                valid_loss = criterion(valid_output, valid_y)
-                if v == 1:
-                    logger.log('debug', 'Epoch {} | Training Loss {} | '
-                               'Validation Loss {}'.format(e + 1, train_loss,
-                               valid_loss), call_loc='MLP')
-                losses.append((train_loss.item(), valid_loss.item()))
-                if best_valid_loss is None or valid_loss < best_valid_loss:
-                    best_model_params = self.state_dict()
-                    best_valid_loss = valid_loss
-                    valid_count = 0
-                else:
-                    valid_count += 1
-                    if valid_count >= patience:
-                        trained_epochs = e + 1
-                        break
-            self.load_state_dict(best_model_params)
-
+            history = self._model.fit(
+                l_x,
+                l_y,
+                validation_data=(v_x, v_y),
+                callbacks=[EarlyStopping(
+                    monitor='val_loss',
+                    patience=250,
+                    verbose=v,
+                    mode='min',
+                    restore_best_weights=True
+                )],
+                epochs=epochs,
+                verbose=v,
+                batch_size=batch_size
+            )
+            epochs = len(history.history['loss'])
         else:
-            for e in range(epochs):
-                train_x, train_y = self._batch(l_x, l_y, batch_size)
-                optimizer.zero_grad()
-                output = self(train_x)
-                loss = criterion(output, train_y)
-                if v == 1:
-                    logger.log('debug', 'Epoch {} | Training Loss {}'
-                               .format(e + 1, loss), call_loc='MLP')
-                losses.append((loss.item(), None))
-                loss.backward()
-                optimizer.step()
+            self._model.fit(
+                l_x,
+                l_y,
+                epochs=epochs,
+                verbose=v,
+                batch_size=batch_size
+            )
 
-        logger.log('debug', 'Training complete after {} epochs'
-                   .format(trained_epochs), call_loc='MLP')
-        return losses
+        logger.log('debug', 'Training complete after {} epochs'.format(epochs),
+                   call_loc='MLP')
 
     def use(self, x: array) -> array:
         '''Uses neural network to predict values for supplied data
-
         Args:
             x (numpy.array): input data to predict for
-
         Returns
             numpy.array: predictions
         '''
 
-        return asarray(self(tensor(x).float()).tolist())
+        with get_default_graph().as_default():
+            return self._model.predict(x)
 
     def save(self, filename: str=None):
-        '''Saves neural network to specified file
-
+        '''Saves neural network to .h5 file
         filename (str): if None, uses MultilayerPerceptron._filename;
             otherwise, saves to this file
         '''
 
         if filename is None:
             filename = self._filename
-        check_ext(filename)
-        save({
-            'layers': self._layers,
-            'state_dict': self.state_dict()
-        }, filename)
+        if H5_EXT.match(filename) is None:
+            raise ValueError(
+                'Invalid filename/extension, must be `.h5`: {}'.format(
+                    filename
+                )
+            )
+        self._model.save(filename)
         logger.log('debug', 'Model saved to {}'.format(filename),
                    call_loc='MLP')
 
     def load(self, filename: str=None):
-        '''Loads neural network from specified file
-
+        '''Loads neural network from .h5 file
         Args:
-            filename (str): if None, uses MultilayerPerceptron._filename;
-                otherwise, loads from this file
+            filename (str): path to .h5 model file
         '''
 
         if filename is None:
             filename = self._filename
-        check_ext(filename)
-        file_contents = load(filename)
-        layers = file_contents['layers']
-        self._layers = []
-        for idx, l in enumerate(layers):
-            if idx == 0:
-                self.add_layer(l[1], l[2], l[0])
-            else:
-                self.add_layer(l[1], l[2])
-        self.load_state_dict(file_contents['state_dict'])
+        self._model = load_model(filename)
         logger.log('debug', 'Model loaded from {}'.format(filename),
                    call_loc='MLP')
-
-    def forward(self, x: tensor) -> tensor:
-        '''Used by torch.nn.Module to perform forward pass through neural
-        network
-
-        Args:
-            x (torch.tensor): data to pass through neural network
-
-        Returns:
-            tensor: final layer's output
-        '''
-
-        for idx, layer in enumerate(self._layers):
-            if layer[2] is None:
-                x = getattr(self, '_l{}'.format(idx))(x)
-            else:
-                x = layer[2](getattr(self, '_l{}'.format(idx))(x))
-        return x
-
-    @staticmethod
-    def _batch(x: array, y: array, batch_size: int) -> array:
-        '''Returns a batch with specified size given input/target data
-
-        Args:
-            x (np.array): input data
-            y (np.array): target data, same # samples as input data
-            batch_size (int): size of the batch
-
-        Returns:
-            tuple: (np.array, np.array), each array of size batch_size
-        '''
-
-        if batch_size >= len(x):
-            x_b = tensor(x).float()
-            y_b = tensor(y).float()
-        else:
-            idxs = choice(arange(len(x)), batch_size, replace=False)
-            x_b = tensor(x[idxs]).float()
-            y_b = tensor(y[idxs]).float()
-        return (x_b, y_b)

--- a/ecnet/models/mlp.py
+++ b/ecnet/models/mlp.py
@@ -10,51 +10,46 @@
 
 # Stdlib imports
 from re import compile, IGNORECASE
-from os import devnull, environ
-import sys
 
 # 3rd party imports
-from tensorflow import get_default_graph, logging
-from numpy import array
-stderr = sys.stderr
-sys.stderr = open(devnull, 'w')
-from keras.backend import clear_session, reset_uids
-from keras.callbacks import EarlyStopping
-from keras.layers import Dense
-from keras.losses import mean_squared_error
-from keras.metrics import mae
-from keras.models import load_model, Sequential
-from keras.optimizers import Adam
-sys.stderr = stderr
+from numpy import arange, array, asarray
+from numpy.random import choice
+from torch import load, relu, save, sigmoid, stack, tensor
+from torch.nn import Linear, Module, MSELoss
+from torch.optim import Adam
 
 # ECNet imports
 from ecnet.utils.logging import logger
 
-environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
-logging.set_verbosity(logging.ERROR)
-
-H5_EXT = compile(r'.*\.h5', flags=IGNORECASE)
+ECNET_EXT = compile(r'.*\.ecnet', flags=IGNORECASE)
 
 
-class MultilayerPerceptron:
+def check_ext(filename: str):
+    '''Ensures the supplied filename has a `.ecnet` extension
 
-    def __init__(self, filename: str='model.h5'):
+    Args:
+        filename (str): supplied filename
+    '''
+
+    if ECNET_EXT.match(filename) is None:
+        raise ValueError('Invalid filename/extension, must be `.ecnet`: {}'
+                         .format(filename))
+
+
+class MultilayerPerceptron(Module):
+
+    def __init__(self, filename: str='model.ecnet'):
         '''MultilayerPerceptron object: fits neural network to supplied inputs
         and targets
 
         Args:
-            filename (str): path to model save location (.h5 extension)
+            filename (str): path to model save location (.ecnet extension)
         '''
 
-        if H5_EXT.match(filename) is None:
-            raise ValueError(
-                'Invalid filename/extension, must be `.h5`: {}'.format(
-                    filename
-                )
-            )
+        super(MultilayerPerceptron, self).__init__()
+        check_ext(filename)
         self._filename = filename
-        clear_session()
-        self._model = Sequential(name=filename.lower().replace('.h5', ''))
+        self._layers = []
 
     def add_layer(self, num_neurons: int, activation: str,
                   input_dim: int=None):
@@ -62,22 +57,39 @@ class MultilayerPerceptron:
 
         Args:
             num_neurons (int): number of neurons for the layer
-            activation (str): activation function for the layer (see Keras
-                activation function documentation)
+            activation (str): activation function for the layer (`sigmoid`,
+                `relu`, `linear`)
             input_dim (int): if not None (input layer), specifies input
                 dimensionality
         '''
 
-        self._model.add(Dense(
-            units=num_neurons,
-            activation=activation,
-            input_shape=(input_dim,)
+        if activation == 'sigmoid' or activation == sigmoid:
+            activation = sigmoid
+        elif activation == 'relu' or activation == relu:
+            activation = relu
+        elif activation == 'linear' or activation is None:
+            activation = None
+        else:
+            raise ValueError('Unknown activation: {}'.format(activation))
+        if input_dim is not None:
+            self._layers.append((
+                input_dim, num_neurons, activation
+            ))
+        else:
+            if len(self._layers) == 0:
+                raise AttributeError('Must include input dimensionality for '
+                                     'first layer')
+            self._layers.append((
+                self._layers[-1][1], num_neurons, activation
+            ))
+        setattr(self, '_l{}'.format(len(self._layers) - 1), Linear(
+            self._layers[-1][0], self._layers[-1][1]
         ))
 
     def fit(self, l_x: array, l_y: array, v_x: array=None, v_y: array=None,
             epochs: int=1500, lr: float=0.001, beta_1: float=0.9,
             beta_2: float=0.999, epsilon: float=0.0000001, decay: float=0.0,
-            v: int=0, batch_size: int=32):
+            v: int=0, batch_size: int=32, patience: int=32) -> list:
         '''Fits neural network to supplied inputs and targets
 
         Args:
@@ -96,48 +108,73 @@ class MultilayerPerceptron:
             decay (float): learning rate decay for Adam optimizer
             v (int): verbose training, `0` for no printing, `1` for printing
             batch_size (int): number of learning samples per batch
+            patience (int): if performing periodic validation, will wait this
+                many epochs for a better validation loss; will terminate
+                training if better loss not found
+
+        Returns:
+            list: list of tuples, (train loss, valid loss) at each epoch; if
+                not performing periodic validation, index 1 of tuple is None
         '''
 
-        self._model.compile(
-            loss=mean_squared_error,
-            optimizer=Adam(
-                lr=lr,
-                beta_1=beta_1,
-                beta_2=beta_2,
-                epsilon=epsilon,
-                decay=decay
-            ),
-            metrics=[mae]
+        criterion = MSELoss()
+        optimizer = Adam(
+            self.parameters(),
+            lr,
+            (beta_1, beta_2),
+            epsilon,
+            decay
         )
 
-        if v_x is not None and v_y is not None:
-            history = self._model.fit(
-                l_x,
-                l_y,
-                validation_data=(v_x, v_y),
-                callbacks=[EarlyStopping(
-                    monitor='val_loss',
-                    patience=250,
-                    verbose=v,
-                    mode='min',
-                    restore_best_weights=True
-                )],
-                epochs=epochs,
-                verbose=v,
-                batch_size=batch_size
-            )
-            epochs = len(history.history['loss'])
-        else:
-            self._model.fit(
-                l_x,
-                l_y,
-                epochs=epochs,
-                verbose=v,
-                batch_size=batch_size
-            )
+        losses = []
+        trained_epochs = epochs
 
-        logger.log('debug', 'Training complete after {} epochs'.format(epochs),
-                   call_loc='MLP')
+        if v_x is not None and v_y is not None:
+            best_model_params = self.state_dict()
+            best_valid_loss = None
+            valid_count = 0
+            for e in range(epochs):
+                train_x, train_y = self._batch(l_x, l_y, batch_size)
+                valid_x, valid_y = self._batch(v_x, v_y, batch_size)
+                optimizer.zero_grad()
+                train_output = self(train_x)
+                train_loss = criterion(train_output, train_y)
+                train_loss.backward()
+                optimizer.step()
+                valid_output = self(valid_x)
+                valid_loss = criterion(valid_output, valid_y)
+                if v == 1:
+                    logger.log('debug', 'Epoch {} | Training Loss {} | '
+                               'Validation Loss {}'.format(e + 1, train_loss,
+                               valid_loss), call_loc='MLP')
+                losses.append((train_loss.item(), valid_loss.item()))
+                if best_valid_loss is None or valid_loss < best_valid_loss:
+                    best_model_params = self.state_dict()
+                    best_valid_loss = valid_loss
+                    valid_count = 0
+                else:
+                    valid_count += 1
+                    if valid_count >= patience:
+                        trained_epochs = e + 1
+                        break
+            self.load_state_dict(best_model_params)
+
+        else:
+            for e in range(epochs):
+                train_x, train_y = self._batch(l_x, l_y, batch_size)
+                optimizer.zero_grad()
+                output = self(train_x)
+                loss = criterion(output, train_y)
+                if v == 1:
+                    logger.log('debug', 'Epoch {} | Training Loss {}'
+                               .format(e + 1, loss), call_loc='MLP')
+                losses.append((loss.item(), None))
+                loss.backward()
+                optimizer.step()
+
+        logger.log('debug', 'Training complete after {} epochs'
+                   .format(trained_epochs), call_loc='MLP')
+        return losses
 
     def use(self, x: array) -> array:
         '''Uses neural network to predict values for supplied data
@@ -149,11 +186,10 @@ class MultilayerPerceptron:
             numpy.array: predictions
         '''
 
-        with get_default_graph().as_default():
-            return self._model.predict(x)
+        return asarray(self(tensor(x).float()).tolist())
 
     def save(self, filename: str=None):
-        '''Saves neural network to .h5 file
+        '''Saves neural network to specified file
 
         filename (str): if None, uses MultilayerPerceptron._filename;
             otherwise, saves to this file
@@ -161,25 +197,73 @@ class MultilayerPerceptron:
 
         if filename is None:
             filename = self._filename
-        if H5_EXT.match(filename) is None:
-            raise ValueError(
-                'Invalid filename/extension, must be `.h5`: {}'.format(
-                    filename
-                )
-            )
-        self._model.save(filename)
+        check_ext(filename)
+        save({
+            'layers': self._layers,
+            'state_dict': self.state_dict()
+        }, filename)
         logger.log('debug', 'Model saved to {}'.format(filename),
                    call_loc='MLP')
 
     def load(self, filename: str=None):
-        '''Loads neural network from .h5 file
+        '''Loads neural network from specified file
 
         Args:
-            filename (str): path to .h5 model file
+            filename (str): if None, uses MultilayerPerceptron._filename;
+                otherwise, loads from this file
         '''
 
         if filename is None:
             filename = self._filename
-        self._model = load_model(filename)
+        check_ext(filename)
+        file_contents = load(filename)
+        layers = file_contents['layers']
+        self._layers = []
+        for idx, l in enumerate(layers):
+            if idx == 0:
+                self.add_layer(l[1], l[2], l[0])
+            else:
+                self.add_layer(l[1], l[2])
+        self.load_state_dict(file_contents['state_dict'])
         logger.log('debug', 'Model loaded from {}'.format(filename),
                    call_loc='MLP')
+
+    def forward(self, x: tensor) -> tensor:
+        '''Used by torch.nn.Module to perform forward pass through neural
+        network
+
+        Args:
+            x (torch.tensor): data to pass through neural network
+
+        Returns:
+            tensor: final layer's output
+        '''
+
+        for idx, layer in enumerate(self._layers):
+            if layer[2] is None:
+                x = getattr(self, '_l{}'.format(idx))(x)
+            else:
+                x = layer[2](getattr(self, '_l{}'.format(idx))(x))
+        return x
+
+    @staticmethod
+    def _batch(x: array, y: array, batch_size: int) -> array:
+        '''Returns a batch with specified size given input/target data
+
+        Args:
+            x (np.array): input data
+            y (np.array): target data, same # samples as input data
+            batch_size (int): size of the batch
+
+        Returns:
+            tuple: (np.array, np.array), each array of size batch_size
+        '''
+
+        if batch_size >= len(x):
+            x_b = tensor(x).float()
+            y_b = tensor(y).float()
+        else:
+            idxs = choice(arange(len(x)), batch_size, replace=False)
+            x_b = tensor(x[idxs]).float()
+            y_b = tensor(y[idxs]).float()
+        return (x_b, y_b)

--- a/ecnet/models/mlp.py
+++ b/ecnet/models/mlp.py
@@ -23,7 +23,7 @@ from tensorflow.keras.optimizers import Adam
 
 from ecnet.utils.logging import logger
 
-os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
+environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
 config.experimental_run_functions_eagerly(True)
 H5_EXT = compile(r'.*\.h5', flags=IGNORECASE)
 

--- a/ecnet/models/mlp.py
+++ b/ecnet/models/mlp.py
@@ -41,6 +41,7 @@ class MultilayerPerceptron:
     def __init__(self, filename: str='model.h5'):
         '''MultilayerPerceptron object: fits neural network to supplied inputs
         and targets
+
         Args:
             filename (str): path to model save location (.h5 extension)
         '''
@@ -58,6 +59,7 @@ class MultilayerPerceptron:
     def add_layer(self, num_neurons: int, activation: str,
                   input_dim: int=None):
         '''Adds a fully-connected layer to the model
+
         Args:
             num_neurons (int): number of neurons for the layer
             activation (str): activation function for the layer (see Keras
@@ -75,8 +77,9 @@ class MultilayerPerceptron:
     def fit(self, l_x: array, l_y: array, v_x: array=None, v_y: array=None,
             epochs: int=1500, lr: float=0.001, beta_1: float=0.9,
             beta_2: float=0.999, epsilon: float=0.0000001, decay: float=0.0,
-            v: int=0, batch_size: int=32, patience: int=128):
+            v: int=0, batch_size: int=32, patience: int=128) -> tuple:
         '''Fits neural network to supplied inputs and targets
+
         Args:
             l_x (numpy.array): learning input data
             l_y (numpy.array): learning target data
@@ -93,6 +96,11 @@ class MultilayerPerceptron:
             decay (float): learning rate decay for Adam optimizer
             v (int): verbose training, `0` for no printing, `1` for printing
             batch_size (int): number of learning samples per batch
+
+        Returns:
+            tuple: (learn losses iterable, valid losses iterable); both
+                iterables are the same size; if not validating, valid losses
+                iterable populated with `None`
         '''
 
         self._model.compile(
@@ -123,24 +131,31 @@ class MultilayerPerceptron:
                 verbose=v,
                 batch_size=batch_size
             )
-            epochs = len(history.history['loss'])
+            learn_loss = history.history['loss']
+            valid_loss = history.history['val_loss']
+            epochs = len(learn_loss)
         else:
-            self._model.fit(
+            history = self._model.fit(
                 l_x,
                 l_y,
                 epochs=epochs,
                 verbose=v,
                 batch_size=batch_size
             )
+            learn_loss = history.history['loss']
+            valid_loss = [None for _ in range(len(learn_loss))]
 
         logger.log('debug', 'Training complete after {} epochs'.format(epochs),
                    call_loc='MLP')
+        return (learn_loss, valid_loss)
 
     def use(self, x: array) -> array:
         '''Uses neural network to predict values for supplied data
+
         Args:
             x (numpy.array): input data to predict for
         Returns
+
             numpy.array: predictions
         '''
 
@@ -167,6 +182,7 @@ class MultilayerPerceptron:
 
     def load(self, filename: str=None):
         '''Loads neural network from .h5 file
+
         Args:
             filename (str): path to .h5 model file
         '''

--- a/ecnet/models/mlp.py
+++ b/ecnet/models/mlp.py
@@ -8,187 +8,207 @@
 # Contains the "MultilayerPerceptron" (feed-forward neural network) class
 #
 
-# Stdlib imports
+from os import environ
 from re import compile, IGNORECASE
-from os import devnull, environ
-import sys
 
-# 3rd party imports
-from tensorflow import get_default_graph, logging
-from numpy import array
-stderr = sys.stderr
-sys.stderr = open(devnull, 'w')
-from keras.backend import clear_session, reset_uids
-from keras.callbacks import EarlyStopping
-from keras.layers import Dense
-from keras.losses import mean_squared_error
-from keras.metrics import mae
-from keras.models import load_model, Sequential
-from keras.optimizers import Adam
-sys.stderr = stderr
+from h5py import File
+from numpy import array, string_, zeros
 
-# ECNet imports
+from tensorflow import config, Tensor
+from tensorflow.keras.callbacks import EarlyStopping
+from tensorflow.keras.layers import Dense
+from tensorflow.keras.losses import MeanSquaredError
+from tensorflow.keras.models import Model
+from tensorflow.keras.optimizers import Adam
+
 from ecnet.utils.logging import logger
 
-environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
-logging.set_verbosity(logging.ERROR)
-
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
+config.experimental_run_functions_eagerly(True)
 H5_EXT = compile(r'.*\.h5', flags=IGNORECASE)
 
 
-class MultilayerPerceptron:
+def check_h5(filename: str):
+    ''' Ensures a given filename has an `.h5` extension
 
-    def __init__(self, filename: str='model.h5'):
-        '''MultilayerPerceptron object: fits neural network to supplied inputs
-        and targets
+    Args:
+        filename (str): filename to check
+    '''
+
+    if H5_EXT.match(filename) is None:
+        raise ValueError(
+            'Invalid filename/extension, must be `.h5`: {}'.format(
+                filename
+            )
+        )
+
+
+class MultilayerPerceptron(Model):
+
+    def __init__(self, filename: str = 'model.h5'):
+        ''' MultilayerPerceptron: Feed-forward neural network; variable number
+        of layers, variable size/activations of layers; handles training,
+        saving/loading of models
 
         Args:
-            filename (str): path to model save location (.h5 extension)
+            filename (str): filename/path for the model (default: `model.h5`)
         '''
 
-        if H5_EXT.match(filename) is None:
-            raise ValueError(
-                'Invalid filename/extension, must be `.h5`: {}'.format(
-                    filename
-                )
-            )
+        super(MultilayerPerceptron, self).__init__()
+        check_h5(filename)
         self._filename = filename
-        clear_session()
-        self._model = Sequential(name=filename.lower().replace('.h5', ''))
+        self._layers = []
 
     def add_layer(self, num_neurons: int, activation: str,
-                  input_dim: int=None):
-        '''Adds a fully-connected layer to the model
+                  input_dim: int = None):
+        ''' add_layer: adds a layer to the MLP; layers are added sequentially;
+        first layer must have input dimensionality specified
 
         Args:
-            num_neurons (int): number of neurons for the layer
-            activation (str): activation function for the layer (see Keras
-                activation function documentation)
-            input_dim (int): if not None (input layer), specifies input
-                dimensionality
+            num_neurons (int): number of neurons in the layer
+            activation (str): activation function used by the layer; refer to
+               https://www.tensorflow.org/api_docs/python/tf/keras/activations
+               for usable activation functions
+            input_dim (int): specify input dimensionality for the first layer;
+               all other layers depend on previous layers' size (number of
+               neurons), should be kept as `None` (default value)
         '''
 
-        self._model.add(Dense(
+        if len(self._layers) == 0:
+            if input_dim is None:
+                raise ValueError('First layer must have input_dim specified')
+
+        self._layers.append(Dense(
             units=num_neurons,
             activation=activation,
             input_shape=(input_dim,)
         ))
 
-    def fit(self, l_x: array, l_y: array, v_x: array=None, v_y: array=None,
-            epochs: int=1500, lr: float=0.001, beta_1: float=0.9,
-            beta_2: float=0.999, epsilon: float=0.0000001, decay: float=0.0,
-            v: int=0, batch_size: int=32, patience: int=128) -> tuple:
-        '''Fits neural network to supplied inputs and targets
+    def call(self, x: Tensor) -> Tensor:
+        ''' call: used by Model.fit (parent) to perform feed-forward operations
 
         Args:
-            l_x (numpy.array): learning input data
-            l_y (numpy.array): learning target data
-            v_x (numpy.array): if not None, periodic validation is performed w/
-                these inputs
-            v_y (numpy.array): if not None, periodic validation is performed w/
-                these targets
-            epochs (int): number of learning epochs if not validating, maximum
-                number of learning epochs if performing periodic validation
-            lr (float): learning rate for Adam optimizer
-            beta_1 (float): beta_1 value for Adam optimizer
-            beta_2 (float): beta_2 value for Adam optimizer
-            epsilon (float): epsilon value for Adam optimizer
-            decay (float): learning rate decay for Adam optimizer
-            v (int): verbose training, `0` for no printing, `1` for printing
-            batch_size (int): number of learning samples per batch
+            x (tf.Tensor): data fed into first layer
 
         Returns:
-            tuple: (learn losses iterable, valid losses iterable); both
-                iterables are the same size; if not validating, valid losses
-                iterable populated with `None`
+            tf.Tensor: data resulting from last layer
         '''
 
-        self._model.compile(
-            loss=mean_squared_error,
-            optimizer=Adam(
-                lr=lr,
-                beta_1=beta_1,
-                beta_2=beta_2,
-                epsilon=epsilon,
-                decay=decay
-            ),
-            metrics=[mae]
-        )
+        for layer in self._layers:
+            x = layer(x)
+        return x
 
-        if v_x is not None and v_y is not None:
-            history = self._model.fit(
-                l_x,
-                l_y,
-                validation_data=(v_x, v_y),
-                callbacks=[EarlyStopping(
-                    monitor='val_loss',
-                    patience=patience,
-                    verbose=v,
-                    mode='min',
-                    restore_best_weights=True
-                )],
-                epochs=epochs,
-                verbose=v,
-                batch_size=batch_size
-            )
-            learn_loss = history.history['loss']
-            valid_loss = history.history['val_loss']
-            epochs = len(learn_loss)
-        else:
-            history = self._model.fit(
-                l_x,
-                l_y,
-                epochs=epochs,
-                verbose=v,
-                batch_size=batch_size
-            )
-            learn_loss = history.history['loss']
-            valid_loss = [None for _ in range(len(learn_loss))]
-
-        logger.log('debug', 'Training complete after {} epochs'.format(epochs),
-                   call_loc='MLP')
-        return (learn_loss, valid_loss)
-
-    def use(self, x: array) -> array:
-        '''Uses neural network to predict values for supplied data
+    def fit(self, l_x: array, l_y: array, v_x: array = None, v_y: array = None,
+            epochs: int = 1500, lr: float = 0.001, beta_1: float = 0.9,
+            beta_2: float = 0.999, epsilon: float = 0.0000001,
+            decay: float = 0.0, v: int = 0, batch_size: int = 32,
+            patience: int = 128) -> tuple:
+        ''' fit: trains model using supplied data; may supply additional data
+        to use as validation set (determines learning cutoff); hyperparameters
+        for Adam optimization function, batch size, patience (if validating)
+        may be specified
 
         Args:
-            x (numpy.array): input data to predict for
-        Returns
+            l_x (np.array): learning input data; each sub-iterable is a sample
+            l_y (np.array): learning target data; each sub-iterable is a sample
+            v_x (np.array): validation input data (`None` for no validation)
+            v_y (np.array): validation target data (`None` for no validation)
+            epochs (int): number of training iterations, max iterations if
+                performing validation
+            lr (float): learning rate of Adam optimization fn
+            beta_1 (float): first moment estimate of Adam optimization fn
+            beta_2 (float): second moment estimate of Adam optimization fn
+            epsilon (float): number to prevent division by zero in Adam fn
+            decay (float): decay of learning date in Adam optimization fn
+            v (int): whether Model.fit (parent) is verbose (1 True, 0 False)
+            batch_size (int): size of each training batch
+            patience (int): maximum number of epochs to wait before better
+                validation loss found; if not found, training terminates, best
+                weights restored
 
-            numpy.array: predictions
+        Returns:
+            tuple: (list: learn losses, list: valid losses); each list equal
+                length; each list element represents loss at corresponding
+                epoch
         '''
 
-        with get_default_graph().as_default():
-            return self._model.predict(x)
+        self.compile(optimizer=Adam(lr=lr, beta_1=beta_1, beta_2=beta_2,
+                                    epsilon=epsilon,
+                                    decay=decay),
+                     loss=MeanSquaredError())
 
-    def save(self, filename: str=None):
-        '''Saves neural network to .h5 file
-        filename (str): if None, uses MultilayerPerceptron._filename;
-            otherwise, saves to this file
+        if v_x is not None and v_y is not None:
+
+            callback = EarlyStopping(monitor='val_loss', patience=patience,
+                                     restore_best_weights=True)
+            history = super().fit(l_x, l_y, batch_size=batch_size,
+                                  epochs=epochs, verbose=v,
+                                  callbacks=[callback],
+                                  validation_data=(v_x, v_y))
+            return (history.history['loss'], history.history['val_loss'])
+
+        else:
+
+            history = super().fit(l_x, l_y, batch_size=batch_size,
+                                  epochs=epochs, verbose=v)
+            return (history.history['loss'], [None for _ in range(epochs)])
+
+    def use(self, x: array) -> array:
+        ''' use: uses the model to predict values for supplied data
+
+        Args:
+            x (np.array): input data to predict for
+
+        Returns:
+            np.array: predicted values
+        '''
+
+        return self.predict(x)
+
+    def save(self, filename: str = None):
+        ''' save: saves the model weights, architecture to either the filename/
+        path specified when object was created, or new, supplied filename/path
+
+        Args:
+            filename (str): new filepath if different than init filename/path
         '''
 
         if filename is None:
             filename = self._filename
-        if H5_EXT.match(filename) is None:
-            raise ValueError(
-                'Invalid filename/extension, must be `.h5`: {}'.format(
-                    filename
-                )
-            )
-        self._model.save(filename)
+        check_h5(filename)
+        self.save_weights(filename, save_format='h5')
+        input_size = self.layers[0].get_config()['batch_input_shape'][1]
+        layer_sizes = [l.get_config()['units'] for l in self.layers]
+        layer_activ = [l.get_config()['activation'] for l in self.layers]
+        with File(filename, 'a') as hf:
+            hf['mlp_input_size'] = input_size
+            hf['mlp_layer_sizes'] = layer_sizes
+            hf['mlp_layer_activ'] = string_(layer_activ)
+        hf.close()
         logger.log('debug', 'Model saved to {}'.format(filename),
                    call_loc='MLP')
 
-    def load(self, filename: str=None):
-        '''Loads neural network from .h5 file
+    def load(self, filename: str = None):
+        ''' load: loads a saved model, restoring the architecture/weights;
+        loads from filename/path specified during object initialization,
+        unless new filename/path specified
 
         Args:
-            filename (str): path to .h5 model file
+            filename (str): new filepath if different than init filename/path
         '''
 
         if filename is None:
             filename = self._filename
-        self._model = load_model(filename)
+        with File(filename, 'r') as hf:
+            input_size = hf.get('mlp_input_size').value
+            layer_sizes = hf.get('mlp_layer_sizes').value
+            layer_activ = hf.get('mlp_layer_activ').value
+        hf.close()
+        self.add_layer(layer_sizes[0], layer_activ[0].decode('ascii'),
+                       input_size)
+        for idx, layer in enumerate(layer_sizes[1:]):
+            self.add_layer(layer, layer_activ[idx].decode('ascii'))
+        self.build(input_shape=(None, input_size))
+        self.load_weights(filename)
         logger.log('debug', 'Model loaded from {}'.format(filename),
                    call_loc='MLP')

--- a/ecnet/server.py
+++ b/ecnet/server.py
@@ -187,7 +187,7 @@ class Server:
 
     def train(self, shuffle: str=None, split: list=None, retrain: bool=False,
               validate: bool=False, selection_set: str=None,
-              selection_fn: str='rmse', model_filename: str='model.ecnet',
+              selection_fn: str='rmse', model_filename: str='model.h5',
               verbose=0) -> list:
         '''Trains neural network(s) using currently-loaded data; single NN if
         no project is created, all candidates if created
@@ -204,7 +204,7 @@ class Server:
                 set; `learn`, `valid`, `train`, `test`, None (all data)
             selection_fn (str): candidates are selected based on this error
                 metric; `rmse`, `mean_abs_error`, `med_abs_error`
-            model_filename (str): if project not created, saves `.ecnet` file
+            model_filename (str): if project not created, saves `.h5` file
                 here
             verbose (int): 1 to display loss at each epoch, 0 otherwise (single
                 model only)
@@ -247,7 +247,7 @@ class Server:
             return None
 
     def use(self, dset: str=None, output_filename: str=None,
-            model_filename: str='model.ecnet') -> list:
+            model_filename: str='model.h5') -> list:
         '''Uses trained neural network(s) to predict for specified set; single
         NN if no project created, best pool candidates if created
 
@@ -255,7 +255,7 @@ class Server:
             dset (str): set to predict for; `learn`, `valid`, `train`, `test`,
                 None (all sets)
             output_filename (str): if supplied, saves results to this CSV file
-            model_filename (str): if supplied, use specified .ecnet model file
+            model_filename (str): if supplied, use specified .h5 model file
 
         Returns:
             list: list of results for specified set
@@ -278,7 +278,7 @@ class Server:
         return results
 
     def errors(self, *args, dset: str=None,
-               model_filename: str='model.ecnet') -> dict:
+               model_filename: str='model.h5') -> dict:
         '''Obtains various errors for specified set
 
         Args:
@@ -286,7 +286,7 @@ class Server:
                 `med_abs_error`, `r2`
             dset (str): set to obtain errors for; `learn`, `valid`, `train`,
                 `test`, None (all sets)
-            model_filename (str): if specified, uses .ecnet model file for error
+            model_filename (str): if specified, uses .h5 model file for error
                 calculations
 
         Returns:

--- a/ecnet/server.py
+++ b/ecnet/server.py
@@ -187,7 +187,7 @@ class Server:
 
     def train(self, shuffle: str=None, split: list=None, retrain: bool=False,
               validate: bool=False, selection_set: str=None,
-              selection_fn: str='rmse', model_filename: str='model.h5'):
+              selection_fn: str='rmse', model_filename: str='model.ecnet'):
         '''Trains neural network(s) using currently-loaded data; single NN if
         no project is created, all candidates if created
 
@@ -203,7 +203,7 @@ class Server:
                 set; `learn`, `valid`, `train`, `test`, None (all data)
             selection_fn (str): candidates are selected based on this error
                 metric; `rmse`, `mean_abs_error`, `med_abs_error`
-            model_filename (str): if project not created, saves Keras h5 model
+            model_filename (str): if project not created, saves `.ecnet` file
                 here
         '''
 
@@ -237,7 +237,7 @@ class Server:
             )
 
     def use(self, dset: str=None, output_filename: str=None,
-            model_filename: str='model.h5') -> list:
+            model_filename: str='model.ecnet') -> list:
         '''Uses trained neural network(s) to predict for specified set; single
         NN if no project created, best pool candidates if created
 
@@ -245,7 +245,7 @@ class Server:
             dset (str): set to predict for; `learn`, `valid`, `train`, `test`,
                 None (all sets)
             output_filename (str): if supplied, saves results to this CSV file
-            model_filename (str): if supplied, use specified .h5 model file
+            model_filename (str): if supplied, use specified .ecnet model file
 
         Returns:
             list: list of results for specified set
@@ -268,7 +268,7 @@ class Server:
         return results
 
     def errors(self, *args, dset: str=None,
-               model_filename: str='model.h5') -> dict:
+               model_filename: str='model.ecnet') -> dict:
         '''Obtains various errors for specified set
 
         Args:
@@ -276,7 +276,7 @@ class Server:
                 `med_abs_error`, `r2`
             dset (str): set to obtain errors for; `learn`, `valid`, `train`,
                 `test`, None (all sets)
-            model_filename (str): if specified, uses .h5 model file for error
+            model_filename (str): if specified, uses .ecnet model file for error
                 calculations
 
         Returns:

--- a/ecnet/server.py
+++ b/ecnet/server.py
@@ -112,7 +112,8 @@ class Server:
                    num_candidates), call_loc='PROJECT')
 
     def limit_inputs(self, limit_num: int, num_estimators: int=None,
-                     output_filename: str=None, **kwargs) -> list:
+                     eval_set: str='learn', output_filename: str=None,
+                     **kwargs) -> list:
         '''Selects `limit_num` influential input parameters using random
         forest regression
 
@@ -122,6 +123,8 @@ class Server:
                 defaults to the total number of inputs
             output_filename (str): if not None, new limited database is saved
                 here
+            eval_set (str): set to perform RFR on (`learn`, `valid`, `train`,
+                `test`, None (all)) (default: `learn`)
             **kwargs: any argument accepted by
                 sklearn.ensemble.RandomForestRegressor
 
@@ -133,7 +136,9 @@ class Server:
             self._df,
             limit_num,
             num_estimators,
-            self._num_processes
+            self._num_processes,
+            eval_set,
+            **kwargs
         )
         self._df.set_inputs([r[0] for r in result])
         self._sets = self._df.package_sets()

--- a/ecnet/server.py
+++ b/ecnet/server.py
@@ -187,7 +187,8 @@ class Server:
 
     def train(self, shuffle: str=None, split: list=None, retrain: bool=False,
               validate: bool=False, selection_set: str=None,
-              selection_fn: str='rmse', model_filename: str='model.ecnet'):
+              selection_fn: str='rmse', model_filename: str='model.ecnet',
+              verbose=0):
         '''Trains neural network(s) using currently-loaded data; single NN if
         no project is created, all candidates if created
 
@@ -205,6 +206,8 @@ class Server:
                 metric; `rmse`, `mean_abs_error`, `med_abs_error`
             model_filename (str): if project not created, saves `.ecnet` file
                 here
+            verbose (int): 1 to display loss at each epoch, 0 otherwise (single
+                model only)
         '''
 
         if self._prj_name is None:
@@ -216,7 +219,8 @@ class Server:
                 selection_fn,
                 retrain,
                 model_filename,
-                validate
+                validate,
+                verbose=verbose
             )
 
         else:

--- a/ecnet/server.py
+++ b/ecnet/server.py
@@ -146,7 +146,7 @@ class Server:
     def tune_hyperparameters(self, num_employers: int, num_iterations: int,
                              shuffle: bool=None, split: list=None,
                              validate: bool=True, eval_set: str=None,
-                             eval_fn: str='rmse'):
+                             eval_fn: str='rmse', epochs: int=300):
         '''Tunes neural network learning hyperparameters using an artificial
         bee colony algorithm; tuned hyperparameters are saved to Server's
         model configuration file
@@ -162,6 +162,7 @@ class Server:
                 `train`, `test`, None (all sets)
             eval_fn (str): error function used to evaluate bee fitness;
                 `rmse`, `mean_abs_error`, `med_abs_error`
+            epochs (int): number of training epochs per bee ANN (def: 300)
         '''
 
         self._vars = tune_hyperparameters(
@@ -174,7 +175,8 @@ class Server:
             split,
             validate,
             eval_set,
-            eval_fn
+            eval_fn,
+            epochs
         )
         save_config(self._vars, self._cf_file)
 

--- a/ecnet/server.py
+++ b/ecnet/server.py
@@ -188,7 +188,7 @@ class Server:
     def train(self, shuffle: str=None, split: list=None, retrain: bool=False,
               validate: bool=False, selection_set: str=None,
               selection_fn: str='rmse', model_filename: str='model.ecnet',
-              verbose=0):
+              verbose=0) -> list:
         '''Trains neural network(s) using currently-loaded data; single NN if
         no project is created, all candidates if created
 
@@ -208,11 +208,15 @@ class Server:
                 here
             verbose (int): 1 to display loss at each epoch, 0 otherwise (single
                 model only)
+
+        Returns:
+            list: if training single model, returns list of learn/valid losses,
+                else None
         '''
 
         if self._prj_name is None:
             logger.log('info', 'Training single model', call_loc='TRAIN')
-            train_model(
+            _, losses = train_model(
                 self._sets,
                 self._vars,
                 selection_set,
@@ -222,6 +226,7 @@ class Server:
                 validate,
                 verbose=verbose
             )
+            return losses
 
         else:
             train_project(
@@ -239,6 +244,7 @@ class Server:
                 selection_fn,
                 self._num_processes
             )
+            return None
 
     def use(self, dset: str=None, output_filename: str=None,
             model_filename: str='model.ecnet') -> list:

--- a/ecnet/server.py
+++ b/ecnet/server.py
@@ -187,7 +187,7 @@ class Server:
 
     def train(self, shuffle: str=None, split: list=None, retrain: bool=False,
               validate: bool=False, selection_set: str=None,
-              selection_fn: str='rmse'):
+              selection_fn: str='rmse', filename: str='model.h5'):
         '''Trains neural network(s) using currently-loaded data; single NN if
         no project is created, all candidates if created
 
@@ -203,6 +203,7 @@ class Server:
                 set; `learn`, `valid`, `train`, `test`, None (all data)
             selection_fn (str): candidates are selected based on this error
                 metric; `rmse`, `mean_abs_error`, `med_abs_error`
+            filename (str): if project not created, saves Keras h5 model here
         '''
 
         if self._prj_name is None:
@@ -213,7 +214,8 @@ class Server:
                 selection_set,
                 selection_fn,
                 retrain,
-                validate=validate
+                filename,
+                validate
             )
 
         else:

--- a/ecnet/server.py
+++ b/ecnet/server.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 #
 # ecnet/server.py
-# v.3.2.3
-# Developed in 2019 by Travis Kessler <travis.j.kessler@gmail.com>
+# v.3.3.0
+# Developed in 2020 by Travis Kessler <travis.j.kessler@gmail.com>
 #
 # Contains the "Server" class, which handles ECNet project creation, neural
 # network model creation, data hand-off to models, prediction error
@@ -26,8 +26,8 @@ from ecnet.utils.server_utils import check_config, create_project,\
 
 class Server:
 
-    def __init__(self, model_config: str='config.yml', prj_file: str=None,
-                 num_processes: int=1):
+    def __init__(self, model_config: str = 'config.yml', prj_file: str = None,
+                 num_processes: int = 1):
         '''Server object: handles data loading, model creation, data-to-model
         hand-off, data input parameter selection, hyperparameter tuning
 
@@ -69,8 +69,8 @@ class Server:
             self._vars = default_config()
             save_config(self._vars, self._cf_file)
 
-    def load_data(self, filename: str, random: bool=False, split: list=None,
-                  normalize: bool=False):
+    def load_data(self, filename: str, random: bool = False,
+                  split: list = None, normalize: bool = False):
         '''Loads data from an ECNet-formatted CSV database
 
         Args:
@@ -90,8 +90,8 @@ class Server:
         self._df.create_sets(random, split)
         self._sets = self._df.package_sets()
 
-    def create_project(self, project_name: str, num_pools: int=1,
-                       num_candidates: int=1):
+    def create_project(self, project_name: str, num_pools: int = 1,
+                       num_candidates: int = 1):
         '''Creates folder hierarchy for a new project
 
         Args:
@@ -111,8 +111,8 @@ class Server:
         logger.log('debug', 'Number of candidates/pool: {}'.format(
                    num_candidates), call_loc='PROJECT')
 
-    def limit_inputs(self, limit_num: int, num_estimators: int=None,
-                     eval_set: str='learn', output_filename: str=None,
+    def limit_inputs(self, limit_num: int, num_estimators: int = None,
+                     eval_set: str = 'learn', output_filename: str = None,
                      **kwargs) -> list:
         '''Selects `limit_num` influential input parameters using random
         forest regression
@@ -149,9 +149,9 @@ class Server:
         return result
 
     def tune_hyperparameters(self, num_employers: int, num_iterations: int,
-                             shuffle: bool=None, split: list=None,
-                             validate: bool=True, eval_set: str=None,
-                             eval_fn: str='rmse', epochs: int=300):
+                             shuffle: bool = None, split: list = None,
+                             validate: bool = True, eval_set: str = None,
+                             eval_fn: str = 'rmse', epochs: int = 300):
         '''Tunes neural network learning hyperparameters using an artificial
         bee colony algorithm; tuned hyperparameters are saved to Server's
         model configuration file
@@ -185,10 +185,10 @@ class Server:
         )
         save_config(self._vars, self._cf_file)
 
-    def train(self, shuffle: str=None, split: list=None, retrain: bool=False,
-              validate: bool=False, selection_set: str=None,
-              selection_fn: str='rmse', model_filename: str='model.h5',
-              verbose=0) -> list:
+    def train(self, shuffle: str = None, split: list = None,
+              retrain: bool = False, validate: bool = False,
+              selection_set: str = None, selection_fn: str = 'rmse',
+              model_filename: str = 'model.h5', verbose: int = 0) -> tuple:
         '''Trains neural network(s) using currently-loaded data; single NN if
         no project is created, all candidates if created
 
@@ -210,8 +210,8 @@ class Server:
                 model only)
 
         Returns:
-            list: if training single model, returns list of learn/valid losses,
-                else None
+            tuple: if training single model, returns tuple of learn/valid
+                losses, else None
         '''
 
         if self._prj_name is None:
@@ -246,8 +246,8 @@ class Server:
             )
             return None
 
-    def use(self, dset: str=None, output_filename: str=None,
-            model_filename: str='model.h5') -> list:
+    def use(self, dset: str = None, output_filename: str = None,
+            model_filename: str = 'model.h5') -> list:
         '''Uses trained neural network(s) to predict for specified set; single
         NN if no project created, best pool candidates if created
 
@@ -277,8 +277,8 @@ class Server:
                        call_loc='USE')
         return results
 
-    def errors(self, *args, dset: str=None,
-               model_filename: str='model.h5') -> dict:
+    def errors(self, *args, dset: str = None,
+               model_filename: str = 'model.h5') -> dict:
         '''Obtains various errors for specified set
 
         Args:
@@ -304,8 +304,8 @@ class Server:
         logger.log('debug', 'Errors: {}'.format(errors), call_loc='ERRORS')
         return errors
 
-    def save_project(self, filename: str=None, clean_up: bool=True,
-                     del_candidates: bool=False):
+    def save_project(self, filename: str = None, clean_up: bool = True,
+                     del_candidates: bool = False):
         '''Saves current state of project to a .prj file
 
         Args:

--- a/ecnet/server.py
+++ b/ecnet/server.py
@@ -187,7 +187,7 @@ class Server:
 
     def train(self, shuffle: str=None, split: list=None, retrain: bool=False,
               validate: bool=False, selection_set: str=None,
-              selection_fn: str='rmse', filename: str='model.h5'):
+              selection_fn: str='rmse', model_filename: str='model.h5'):
         '''Trains neural network(s) using currently-loaded data; single NN if
         no project is created, all candidates if created
 
@@ -203,7 +203,8 @@ class Server:
                 set; `learn`, `valid`, `train`, `test`, None (all data)
             selection_fn (str): candidates are selected based on this error
                 metric; `rmse`, `mean_abs_error`, `med_abs_error`
-            filename (str): if project not created, saves Keras h5 model here
+            model_filename (str): if project not created, saves Keras h5 model
+                here
         '''
 
         if self._prj_name is None:
@@ -214,7 +215,7 @@ class Server:
                 selection_set,
                 selection_fn,
                 retrain,
-                filename,
+                model_filename,
                 validate
             )
 
@@ -235,7 +236,8 @@ class Server:
                 self._num_processes
             )
 
-    def use(self, dset: str=None, output_filename: str=None) -> list:
+    def use(self, dset: str=None, output_filename: str=None,
+            model_filename: str='model.h5') -> list:
         '''Uses trained neural network(s) to predict for specified set; single
         NN if no project created, best pool candidates if created
 
@@ -243,13 +245,14 @@ class Server:
             dset (str): set to predict for; `learn`, `valid`, `train`, `test`,
                 None (all sets)
             output_filename (str): if supplied, saves results to this CSV file
+            model_filename (str): if supplied, use specified .h5 model file
 
         Returns:
             list: list of results for specified set
         '''
 
         if self._prj_name is None:
-            results = use_model(self._sets, dset)
+            results = use_model(self._sets, dset, model_filename)
 
         else:
             results = use_project(
@@ -264,7 +267,8 @@ class Server:
                        call_loc='USE')
         return results
 
-    def errors(self, *args, dset: str=None) -> dict:
+    def errors(self, *args, dset: str=None,
+               model_filename: str='model.h5') -> dict:
         '''Obtains various errors for specified set
 
         Args:
@@ -272,6 +276,8 @@ class Server:
                 `med_abs_error`, `r2`
             dset (str): set to obtain errors for; `learn`, `valid`, `train`,
                 `test`, None (all sets)
+            model_filename (str): if specified, uses .h5 model file for error
+                calculations
 
         Returns:
             dict: {'error_fn', value ...} with supplied errors
@@ -280,7 +286,7 @@ class Server:
         for err in args:
             logger.log('debug', 'Calculating {} for {} set'.format(err, dset),
                        call_loc='ERRORS')
-        preds = self.use(dset)
+        preds = self.use(dset, model_filename=model_filename)
         y_vals = get_y(self._sets, dset)
         errors = {}
         for err in args:

--- a/ecnet/tasks/limit_inputs.py
+++ b/ecnet/tasks/limit_inputs.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 #
 # ecnet/tasks/limit_inputs.py
-# v.3.2.3
-# Developed in 2019 by Travis Kessler <travis.j.kessler@gmail.com>
+# v.3.3.0
+# Developed in 2020 by Travis Kessler <travis.j.kessler@gmail.com>
 #
 # Contains functions for selecting influential input parameters
 #
@@ -21,8 +21,8 @@ from ecnet.utils.logging import logger
 from ecnet.utils.server_utils import get_x, get_y
 
 
-def limit_rforest(df: DataFrame, limit_num: int, num_estimators: int=None,
-                  num_processes: int=1, eval_set: str='learn',
+def limit_rforest(df: DataFrame, limit_num: int, num_estimators: int = None,
+                  num_processes: int = 1, eval_set: str = 'learn',
                   **kwargs) -> list:
     '''Uses random forest regression to select input parameters
 

--- a/ecnet/tasks/training.py
+++ b/ecnet/tasks/training.py
@@ -83,7 +83,7 @@ def train_project(prj_name: str, num_pools: int, num_candidates: int,
                 pool_errors[pool].append(train_model(
                     sets, vars, selection_set, selection_fn, retrain, filename,
                     validate
-                ))
+                )[0])
 
             if shuffle is not None:
                 df.shuffle(sets=shuffle, split=split)
@@ -93,7 +93,7 @@ def train_project(prj_name: str, num_pools: int, num_candidates: int,
         train_pool.close()
         train_pool.join()
         for p_idx, pool in enumerate(pool_errors):
-            pool_errors[p_idx] = [e.get() for e in pool]
+            pool_errors[p_idx] = [e.get()[0] for e in pool]
 
     logger.log('debug', 'Pool errors: {}'.format(pool_errors),
                call_loc='TRAIN')

--- a/ecnet/tasks/training.py
+++ b/ecnet/tasks/training.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 #
 # ecnet/tasks/training.py
-# v.3.2.3
-# Developed in 2019 by Travis Kessler <travis.j.kessler@gmail.com>
+# v.3.3.0
+# Developed in 2020 by Travis Kessler <travis.j.kessler@gmail.com>
 #
 # Contains function for project training (multiprocessed training)
 #

--- a/ecnet/tasks/training.py
+++ b/ecnet/tasks/training.py
@@ -72,7 +72,7 @@ def train_project(prj_name: str, num_pools: int, num_candidates: int,
                 candidate,
                 model=True
             )
-            save_df(df, filename.replace('model.ecnet', 'data.d'))
+            save_df(df, filename.replace('model.h5', 'data.d'))
 
             if num_processes > 1:
                 pool_errors[pool].append(train_pool.apply_async(
@@ -108,6 +108,6 @@ def train_project(prj_name: str, num_pools: int, num_candidates: int,
         pool_fp = get_candidate_path(prj_name, p_idx, p_best=True)
         resave_model(candidate_fp, pool_fp)
         resave_df(
-            candidate_fp.replace('model.ecnet', 'data.d'),
-            pool_fp.replace('model.ecnet', 'data.d')
+            candidate_fp.replace('model.h5', 'data.d'),
+            pool_fp.replace('model.h5', 'data.d')
         )

--- a/ecnet/tasks/training.py
+++ b/ecnet/tasks/training.py
@@ -72,7 +72,7 @@ def train_project(prj_name: str, num_pools: int, num_candidates: int,
                 candidate,
                 model=True
             )
-            save_df(df, filename.replace('model.h5', 'data.d'))
+            save_df(df, filename.replace('model.ecnet', 'data.d'))
 
             if num_processes > 1:
                 pool_errors[pool].append(train_pool.apply_async(
@@ -108,6 +108,6 @@ def train_project(prj_name: str, num_pools: int, num_candidates: int,
         pool_fp = get_candidate_path(prj_name, p_idx, p_best=True)
         resave_model(candidate_fp, pool_fp)
         resave_df(
-            candidate_fp.replace('model.h5', 'data.d'),
-            pool_fp.replace('model.h5', 'data.d')
+            candidate_fp.replace('model.ecnet', 'data.d'),
+            pool_fp.replace('model.ecnet', 'data.d')
         )

--- a/ecnet/tasks/tuning.py
+++ b/ecnet/tasks/tuning.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 #
 # ecnet/tasks/tuning.py
-# v.3.2.3
-# Developed in 2019 by Travis Kessler <travis.j.kessler@gmail.com>
+# v.3.3.0
+# Developed in 2020 by Travis Kessler <travis.j.kessler@gmail.com>
 #
 # Contains functions/fitness functions for tuning hyperparameters
 #
@@ -22,10 +22,10 @@ from ecnet.utils.server_utils import default_config, train_model
 
 
 def tune_hyperparameters(df: DataFrame, vars: dict, num_employers: int,
-                         num_iterations: int, num_processes: int=1,
-                         shuffle: str=None, split: list=None,
-                         validate: bool=True, eval_set: str=None,
-                         eval_fn: str='rmse', epochs: int=300) -> dict:
+                         num_iterations: int, num_processes: int = 1,
+                         shuffle: str = None, split: list = None,
+                         validate: bool = True, eval_set: str = None,
+                         eval_fn: str = 'rmse', epochs: int = 300) -> dict:
     '''Tunes neural network learning/architecture hyperparameters
 
     Args:

--- a/ecnet/tasks/tuning.py
+++ b/ecnet/tasks/tuning.py
@@ -73,10 +73,10 @@ def tune_hyperparameters(df: DataFrame, vars: dict, num_employers: int,
     }
 
     value_ranges = [
-        ('float', (1e-9, 1e-4)),    # Learning rate decay
-        ('float', (1e-5, 0.1)),     # Learning rate
-        ('int', (1, len(df))),      # Batch size
-        ('int', (64, 1024))         # Patience
+        ('float', (1e-9, 1e-4)),            # Learning rate decay
+        ('float', (1e-5, 0.1)),             # Learning rate
+        ('int', (1, len(df.learn_set))),    # Batch size
+        ('int', (64, 1024))                 # Patience
     ]
 
     for _ in range(len(vars['hidden_layers'])):

--- a/ecnet/tasks/tuning.py
+++ b/ecnet/tasks/tuning.py
@@ -76,7 +76,7 @@ def tune_hyperparameters(df: DataFrame, vars: dict, num_employers: int,
         ('float', (1e-9, 1e-4)),    # Learning rate decay
         ('float', (1e-5, 0.1)),     # Learning rate
         ('int', (1, len(df))),      # Batch size
-        ('int', (1, 1600))          # Patience
+        ('int', (64, 1024))         # Patience
     ]
 
     for _ in range(len(vars['hidden_layers'])):

--- a/ecnet/tools/database.py
+++ b/ecnet/tools/database.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 #
 # ecnet/tools/database.py
-# v.3.2.3
-# Developed in 2019 by Travis Kessler <travis.j.kessler@gmail.com>
+# v.3.3.0
+# Developed in 2020 by Travis Kessler <travis.j.kessler@gmail.com>
 #
 # Contains functions for creating ECNet-formatted databases
 #
@@ -20,7 +20,7 @@ from padelpy import from_mdl, from_smiles
 
 try:
     import pybel
-except:
+except ImportError:
     pybel = None
 
 
@@ -35,9 +35,9 @@ class _Molecule:
         self.inputs = None
 
 
-def create_db(smiles: list, db_name: str, targets: list=None,
-              id_prefix: str='', extra_strings: dict={}, backend: str='padel',
-              convert_mdl: bool=False):
+def create_db(smiles: list, db_name: str, targets: list = None,
+              id_prefix: str = '', extra_strings: dict = {},
+              backend: str = 'padel', convert_mdl: bool = False):
     ''' create_db: creates an ECNet-formatted database from SMILES strings
     using either PaDEL-Descriptor or alvaDesc software; using alvaDesc
     requires a valid installation/license of alvaDesc

--- a/ecnet/tools/plotting.py
+++ b/ecnet/tools/plotting.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 #
 # ecnet/tools/plotting.py
-# v.3.2.3
-# Developed in 2019 by Travis Kessler <travis.j.kessler@gmail.com>
+# v.3.3.0
+# Developed in 2020 by Travis Kessler <travis.j.kessler@gmail.com>
 #
 # Contains functions/classes for creating various plots
 #
@@ -18,9 +18,10 @@ from matplotlib.offsetbox import AnchoredText
 
 class ParityPlot:
 
-    def __init__(self, title: str='Parity Plot',
-                 x_label: str='Experimental Value',
-                 y_label: str='Predicted Value', font: str='Times New Roman'):
+    def __init__(self, title: str = 'Parity Plot',
+                 x_label: str = 'Experimental Value',
+                 y_label: str = 'Predicted Value',
+                 font: str = 'Times New Roman'):
         ''' ParityPlot: creates a plot of predicted values vs. experimental
         data relative to a 1:1 parity line
 
@@ -39,7 +40,7 @@ class ParityPlot:
         self._min_val = 0
         self._labels = None
 
-    def add_series(self, x_vals, y_vals, name: str=None, color: str=None):
+    def add_series(self, x_vals, y_vals, name: str = None, color: str = None):
         ''' Adds data to the plot
 
         Args:
@@ -67,7 +68,7 @@ class ParityPlot:
         if y_min < self._min_val:
             self._min_val = y_min
 
-    def add_error_bars(self, error: float, label: str=None):
+    def add_error_bars(self, error: float, label: str = None):
         ''' Adds error bars, +/- the error relative to the 1:1 parity line
 
         Args:
@@ -96,7 +97,7 @@ class ParityPlot:
         self._add_parity_line()
         plt.savefig(filename)
 
-    def _add_parity_line(self, offset: float=0.0):
+    def _add_parity_line(self, offset: float = 0.0):
         ''' Adds a 1:1 parity line
 
         Args:

--- a/ecnet/tools/project.py
+++ b/ecnet/tools/project.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 #
 # ecnet/tools/project.py
-# v.3.2.3
-# Developed in 2019 by Travis Kessler <travis.j.kessler@gmail.com>
+# v.3.3.0
+# Developed in 2020 by Travis Kessler <travis.j.kessler@gmail.com>
 #
 # Contains functions for predicting data using pre-existing .prj files
 #
@@ -20,8 +20,8 @@ from ecnet.utils.logging import logger
 from ecnet.tools.database import create_db
 
 
-def predict(smiles: list, prj_file: str, results_file: str=None,
-            backend: str='padel') -> list:
+def predict(smiles: list, prj_file: str, results_file: str = None,
+            backend: str = 'padel') -> list:
     ''' predict: predicts values for supplied molecules (SMILES strings) using
     pre-existing ECNet project (.prj) file
 

--- a/ecnet/utils/data_utils.py
+++ b/ecnet/utils/data_utils.py
@@ -371,7 +371,7 @@ class DataFrame:
             data_rows.append(data_row)
         rows.extend(sorted(data_rows, key=lambda x: x[0]))
 
-        with open(filename, 'w') as csv_file:
+        with open(filename, 'w', encoding='utf8') as csv_file:
             wr = writer(csv_file, quoting=QUOTE_ALL, lineterminator='\n')
             for row in rows:
                 wr.writerow(row)
@@ -437,7 +437,7 @@ def save_results(results: list, dset: str, df: DataFrame, filename: str):
         data_rows.append(data_row)
     rows.extend(sorted(data_rows, key=lambda x: x[0]))
 
-    with open(filename, 'w') as csv_file:
+    with open(filename, 'w', encoding='utf8') as csv_file:
         wr = writer(csv_file, quoting=QUOTE_ALL, lineterminator='\n')
         for row in rows:
             wr.writerow(row)

--- a/ecnet/utils/data_utils.py
+++ b/ecnet/utils/data_utils.py
@@ -58,7 +58,7 @@ class DataFrame:
         if '.csv' not in filename:
             filename += '.csv'
         try:
-            with open(filename, newline='') as file:
+            with open(filename, newline='', encoding='utf8') as file:
                 rows = list(reader(file))
         except FileNotFoundError:
             raise Exception('CSV database not found: {}'.format(filename))

--- a/ecnet/utils/data_utils.py
+++ b/ecnet/utils/data_utils.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 #
 # ecnet/utils/data_utils.py
-# v.3.2.3
-# Developed in 2019 by Travis Kessler <travis.j.kessler@gmail.com>
+# v.3.3.0
+# Developed in 2020 by Travis Kessler <travis.j.kessler@gmail.com>
 #
 # Contains functions/classes for loading data, saving data, saving results
 #
@@ -33,8 +33,8 @@ class DataPoint:
 class PackagedData:
 
     def __init__(self):
-        '''PackagedData object: contains lists of input and target data for data
-        set assignments
+        '''PackagedData object: contains lists of input and target data for
+        data set assignments
         '''
 
         self.learn_x = []
@@ -112,7 +112,7 @@ class DataFrame:
 
         return len(self.data_points)
 
-    def create_sets(self, random: bool=False, split: list=[0.7, 0.2, 0.1]):
+    def create_sets(self, random: bool = False, split: list = [0.7, 0.2, 0.1]):
         '''Creates learning, validation and test sets
 
         Args:
@@ -167,9 +167,9 @@ class DataFrame:
         logger.log('debug', 'Number of entries in test set: {}'.format(
                    len(self.test_set)), call_loc='DF')
 
-    def create_sorted_sets(self, sort_str: str, split: list=[0.7, 0.2, 0.1]):
-        '''Creates random learn, validate and test sets, ensuring data points with
-        the supplied sort string are split proportionally between the sets
+    def create_sorted_sets(self, sort_str: str, split: list = [0.7, 0.2, 0.1]):
+        '''Creates random learn, validate and test sets, ensuring data points
+        with the supplied sort string are split proportionally between the sets
 
         Args:
             sort_str (str): database STRING value used to sort data points
@@ -239,7 +239,7 @@ class DataFrame:
                         (float(getattr(pt, inp)) - v_min) / (v_max - v_min)
                     )
 
-    def shuffle(self, sets: str='all', split: list=[0.7, 0.2, 0.1]):
+    def shuffle(self, sets: str = 'all', split: list = [0.7, 0.2, 0.1]):
         '''Shuffles learning, validation and test sets or learning and
         validation sets
 

--- a/ecnet/utils/error_utils.py
+++ b/ecnet/utils/error_utils.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 #
 # ecnet/utils/error_utils.py
-# v.3.2.3
-# Developed in 2019 by Travis Kessler <Travis_Kessler@student.uml.edu>
+# v.3.3.0
+# Developed in 2020 by Travis Kessler <Travis_Kessler@student.uml.edu>
 #
 # Contains functions for error calculations
 #

--- a/ecnet/utils/logging.py
+++ b/ecnet/utils/logging.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 #
 # ecnet/utils/logging.py
-# v.3.2.3
-# Developed in 2019 by Travis Kessler <Travis_Kessler@student.uml.edu>
+# v.3.3.0
+# Developed in 2020 by Travis Kessler <Travis_Kessler@student.uml.edu>
 #
 # Contains logger used by ECNet
 #

--- a/ecnet/utils/server_utils.py
+++ b/ecnet/utils/server_utils.py
@@ -367,7 +367,7 @@ def save_project(prj_name: str, filename: str, config_filename: str,
 
 def train_model(sets: PackagedData, vars: dict, eval_set: str, eval_fn: str,
                 retrain: bool=False, filename: str='model.ecnet',
-                validate: bool=True, save: bool=True) -> float:
+                validate: bool=True, save: bool=True, verbose: int=0) -> float:
     '''Trains neural network
 
     Args:
@@ -380,6 +380,8 @@ def train_model(sets: PackagedData, vars: dict, eval_set: str, eval_fn: str,
         retrain (bool): if True, opens model for additional training
         filename (str): path to .ecnet model file, loads from this if retraining
         save (bool): if True, saves model to `filename`
+        verbose (int): 1 to display loss at each epoch, 0 otherwise (single
+                model only)
 
     Returns:
         float: error of evaluated set
@@ -407,7 +409,8 @@ def train_model(sets: PackagedData, vars: dict, eval_set: str, eval_fn: str,
             beta_2=vars['beta_2'],
             epsilon=vars['epsilon'],
             decay=vars['decay'],
-            batch_size=vars['batch_size']
+            batch_size=vars['batch_size'],
+            v=verbose
         )
     else:
         model.fit(
@@ -419,7 +422,8 @@ def train_model(sets: PackagedData, vars: dict, eval_set: str, eval_fn: str,
             beta_2=vars['beta_2'],
             epsilon=vars['epsilon'],
             decay=vars['decay'],
-            batch_size=vars['batch_size']
+            batch_size=vars['batch_size'],
+            v=verbose
         )
     if save:
         model.save()

--- a/ecnet/utils/server_utils.py
+++ b/ecnet/utils/server_utils.py
@@ -65,10 +65,10 @@ def default_config() -> dict:
 
     return {
         'epochs': 3000,
-        'learning_rate': 0.001,
+        'learning_rate': 0.01,
         'beta_1': 0.9,
         'beta_2': 0.999,
-        'epsilon': 0.0000001,
+        'epsilon': 1e-8,
         'decay': 0.0,
         'hidden_layers': [
             [32, 'relu'],

--- a/ecnet/utils/server_utils.py
+++ b/ecnet/utils/server_utils.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 #
 # ecnet/utils/server_utils.py
-# v.3.2.3
-# Developed in 2019 by Travis Kessler <travis.j.kessler@gmail.com>
+# v.3.3.0
+# Developed in 2020 by Travis Kessler <travis.j.kessler@gmail.com>
 #
 # Contains functions used by ecnet.Server
 #
@@ -80,8 +80,8 @@ def default_config() -> dict:
     }
 
 
-def get_candidate_path(prj: str, pool: int, candidate: int=None,
-                       model: bool=False, p_best: bool=False) -> str:
+def get_candidate_path(prj: str, pool: int, candidate: int = None,
+                       model: bool = False, p_best: bool = False) -> str:
     '''Get path to various states of model.h5 files
 
     Args:
@@ -367,8 +367,9 @@ def save_project(prj_name: str, filename: str, config_filename: str,
 
 
 def train_model(sets: PackagedData, vars: dict, eval_set: str, eval_fn: str,
-                retrain: bool=False, filename: str='model.h5',
-                validate: bool=True, save: bool=True, verbose: int=0) -> tuple:
+                retrain: bool = False, filename: str = 'model.h5',
+                validate: bool = True, save: bool = True,
+                verbose: int = 0) -> tuple:
     '''Trains neural network
 
     Args:
@@ -385,7 +386,7 @@ def train_model(sets: PackagedData, vars: dict, eval_set: str, eval_fn: str,
                 model only)
 
     Returns:
-        tuple: (error of evaluated set, list of learn/valid losses)
+        tuple: (error of evaluated set, tuple of learn/valid losses)
     '''
 
     model = MultilayerPerceptron(filename=filename)
@@ -438,7 +439,7 @@ def train_model(sets: PackagedData, vars: dict, eval_set: str, eval_fn: str,
 
 
 def use_model(sets: PackagedData, dset: str,
-              filename: str='model.h5') -> array:
+              filename: str = 'model.h5') -> array:
     '''Uses existing model to predict data
 
     Args:

--- a/ecnet/utils/server_utils.py
+++ b/ecnet/utils/server_utils.py
@@ -82,13 +82,13 @@ def default_config() -> dict:
 
 def get_candidate_path(prj: str, pool: int, candidate: int=None,
                        model: bool=False, p_best: bool=False) -> str:
-    '''Get path to various states of model.ecnet files
+    '''Get path to various states of model.h5 files
 
     Args:
         prj (str): project name
         pool (int): pool number
         candidate (int): candidate number
-        model (bool): if True, appends `model.ecnet` to path
+        model (bool): if True, appends `model.h5` to path
         p_best (bool): if True, removes candidate folder from path
 
     Returns:
@@ -100,13 +100,13 @@ def get_candidate_path(prj: str, pool: int, candidate: int=None,
             prj,
             'pool_{}'.format(pool),
             'candidate_{}'.format(candidate),
-            'model.ecnet'
+            'model.h5'
         )
     elif p_best:
         return path.join(
             prj,
             'pool_{}'.format(pool),
-            'model.ecnet'
+            'model.h5'
         )
     else:
         return path.join(
@@ -288,7 +288,7 @@ def resave_df(old: str, new: str):
 
 
 def resave_model(old: str, new: str):
-    '''Resaves .ecnet model file
+    '''Resaves .h5 model file
 
     Args:
         old (str): path to existing file
@@ -367,7 +367,7 @@ def save_project(prj_name: str, filename: str, config_filename: str,
 
 
 def train_model(sets: PackagedData, vars: dict, eval_set: str, eval_fn: str,
-                retrain: bool=False, filename: str='model.ecnet',
+                retrain: bool=False, filename: str='model.h5',
                 validate: bool=True, save: bool=True, verbose: int=0) -> tuple:
     '''Trains neural network
 
@@ -379,7 +379,7 @@ def train_model(sets: PackagedData, vars: dict, eval_set: str, eval_fn: str,
         eval_fn (str): error function to evaluate the model; `rmse`,
             `mean_abs_error`, `med_abs_error`
         retrain (bool): if True, opens model for additional training
-        filename (str): path to .ecnet model file, loads from this if retraining
+        filename (str): path to .h5 model file, loads from this if retraining
         save (bool): if True, saves model to `filename`
         verbose (int): 1 to display loss at each epoch, 0 otherwise (single
                 model only)
@@ -438,14 +438,14 @@ def train_model(sets: PackagedData, vars: dict, eval_set: str, eval_fn: str,
 
 
 def use_model(sets: PackagedData, dset: str,
-              filename: str='model.ecnet') -> array:
+              filename: str='model.h5') -> array:
     '''Uses existing model to predict data
 
     Args:
         sets (ecnet.utils.data_utils.PackagedData): data sets
         dset (str): set to predict for; `learn`, `valid`, `train`, `test`,
             None (all sets)
-        filename (str): path to existing .ecnet model file
+        filename (str): path to existing .h5 model file
 
     Returns:
         numpy.array: predicted data

--- a/ecnet/utils/server_utils.py
+++ b/ecnet/utils/server_utils.py
@@ -81,13 +81,13 @@ def default_config() -> dict:
 
 def get_candidate_path(prj: str, pool: int, candidate: int=None,
                        model: bool=False, p_best: bool=False) -> str:
-    '''Get path to various states of model.h5 files
+    '''Get path to various states of model.ecnet files
 
     Args:
         prj (str): project name
         pool (int): pool number
         candidate (int): candidate number
-        model (bool): if True, appends `model.h5` to path
+        model (bool): if True, appends `model.ecnet` to path
         p_best (bool): if True, removes candidate folder from path
 
     Returns:
@@ -99,13 +99,13 @@ def get_candidate_path(prj: str, pool: int, candidate: int=None,
             prj,
             'pool_{}'.format(pool),
             'candidate_{}'.format(candidate),
-            'model.h5'
+            'model.ecnet'
         )
     elif p_best:
         return path.join(
             prj,
             'pool_{}'.format(pool),
-            'model.h5'
+            'model.ecnet'
         )
     else:
         return path.join(
@@ -287,7 +287,7 @@ def resave_df(old: str, new: str):
 
 
 def resave_model(old: str, new: str):
-    '''Resaves .h5 model file
+    '''Resaves .ecnet model file
 
     Args:
         old (str): path to existing file
@@ -366,7 +366,7 @@ def save_project(prj_name: str, filename: str, config_filename: str,
 
 
 def train_model(sets: PackagedData, vars: dict, eval_set: str, eval_fn: str,
-                retrain: bool=False, filename: str='model.h5',
+                retrain: bool=False, filename: str='model.ecnet',
                 validate: bool=True, save: bool=True) -> float:
     '''Trains neural network
 
@@ -378,7 +378,7 @@ def train_model(sets: PackagedData, vars: dict, eval_set: str, eval_fn: str,
         eval_fn (str): error function to evaluate the model; `rmse`,
             `mean_abs_error`, `med_abs_error`
         retrain (bool): if True, opens model for additional training
-        filename (str): path to .h5 model file, loads from this if retraining
+        filename (str): path to .ecnet model file, loads from this if retraining
         save (bool): if True, saves model to `filename`
 
     Returns:
@@ -431,14 +431,14 @@ def train_model(sets: PackagedData, vars: dict, eval_set: str, eval_fn: str,
 
 
 def use_model(sets: PackagedData, dset: str,
-              filename: str='model.h5') -> array:
+              filename: str='model.ecnet') -> array:
     '''Uses existing model to predict data
 
     Args:
         sets (ecnet.utils.data_utils.PackagedData): data sets
         dset (str): set to predict for; `learn`, `valid`, `train`, `test`,
             None (all sets)
-        filename (str): path to existing .h5 model file
+        filename (str): path to existing .ecnet model file
 
     Returns:
         numpy.array: predicted data

--- a/ecnet/workflows/__init__.py
+++ b/ecnet/workflows/__init__.py
@@ -1,0 +1,2 @@
+import ecnet.workflows.ecrl_workflow
+import ecnet.workflows.workflow_utils

--- a/ecnet/workflows/ecrl_workflow.py
+++ b/ecnet/workflows/ecrl_workflow.py
@@ -1,0 +1,166 @@
+from ecnet.tasks.tuning import tune_hyperparameters
+from ecnet.tools.database import create_db
+from ecnet.tools.plotting import ParityPlot
+from ecnet.utils.data_utils import DataFrame
+from ecnet.utils.error_utils import calc_med_abs_error, calc_r2
+from ecnet.utils.logging import logger
+from ecnet.utils.server_utils import default_config, save_config, train_model,\
+    use_model
+from workflow_utils import find_optimal_num_inputs, prop_range_from_split
+# from ecnet.workflows.workflow_utils import find_optimal_num_inputs,\
+#     prop_range_from_split
+
+from datetime import datetime
+
+from matplotlib import pyplot as plt
+
+
+def create_model(prop_abvr: str, smiles: list=None, targets: list=None,
+                 db_name: str=None, qspr_backend: str='padel',
+                 create_plots: bool=True, data_split: list=[0.7, 0.2, 0.1],
+                 log_level: str='info', log_to_file: bool=True,
+                 num_processes: int=1):
+    ''' create_model: ECRL's database/model creation workflow for all
+    publications
+
+    Args:
+        prop_abvr (str): abbreviation for the property name (e.g. CN)
+        smiles (list): if supplied with targets, creates a new database
+        targets (list): if supplied with smiles, creates a new database
+        db_name (str): you may supply an existing ECNet-formatted database
+        qspr_backend (str): if creating new database, generation software to
+            use (`padel`, `alvadesc`)
+        create_plots (bool): if True, creates plots for median absolute error
+            vs. number of descriptors as inputs, parity plot for all sets
+        data_split (list): [learn %, valid %, test %] for all supplied data
+        log_level (str): `debug`, `info`, `warn`, `error`, `crit`
+        log_to_file (bool): if True, saves workflow logs to a file in `logs`
+            directory
+        num_processes (int): number of concurrent processes to use for various
+            tasks
+    '''
+
+    # Initialize logging
+    logger.stream_level = log_level
+    if log_to_file:
+        logger.file_level = log_level
+
+    # If database not supplied, create database from supplied SMILES, targets
+    if db_name is None:
+        if smiles is None or targets is None:
+            raise ValueError('Must supply SMILES and target values')
+        db_name = datetime.now().strftime('{}_model_%Y%m%d.csv'.format(
+            prop_abvr
+        ))
+        logger.log('info', 'Creating database {}...'.format(db_name),
+                   'WORKFLOW')
+        create_db(smiles, db_name, targets, prop_abvr, backend=qspr_backend)
+        logger.log('info', 'Created database {}'.format(db_name), 'WORKFLOW')
+
+    # Create database split, each subset has proportionally equal number of
+    #   compounds based on range of experimental/target values
+    logger.log('info', 'Creating optimal data split...', 'WORKFLOW')
+    prop_range_from_split(db_name, data_split)
+    logger.log('info', 'Created optimal data split', 'WORKFLOW')
+    df = DataFrame(db_name)
+    df.create_sets()
+    logger.log('info', '\tLearning set: {}'.format(len(df.learn_set)),
+               'WORKFLOW')
+    logger.log('info', '\tValidation set: {}'.format(len(df.valid_set)),
+               'WORKFLOW')
+    logger.log('info', '\tTest set: {}'.format(len(df.test_set)), 'WORKFLOW')
+
+    # Find optimal number of QSPR input variables
+    logger.log('info', 'Finding optimal number of inputs...', 'WORKFLOW')
+    errors, desc = find_optimal_num_inputs(db_name, 'valid', num_processes)
+    df = DataFrame(db_name)
+    df.set_inputs(desc)
+    df.save(db_name)
+    logger.log('info', 'Found optimal number of inputs', 'WORKFLOW')
+    logger.log('info', '\tNumber of inputs: {}'.format(len(df._input_names)),
+               'WORKFLOW')
+
+    # Plot the curve of MAE vs. num. desc. added, if desired
+    if create_plots:
+        logger.log('info', 'Creating plot of MAE vs. descriptors...',
+                   'WORKFLOW')
+        num_add = [e[0] for e in errors]
+        maes = [e[1] for e in errors]
+        opt_num = len(desc)
+        plt.clf()
+        plt.rcParams['font.family'] = 'Times New Roman'
+        plt.plot(num_add, maes, c='blue')
+        plt.axvline(x=opt_num, c='red', linestyle='--')
+        plt.xlabel('Number of Descriptors as ANN Input Variables')
+        plt.ylabel('Median Absolute Error of {} Predictions'.format(prop_abvr))
+        plt.savefig(db_name.replace('.csv', '_desc_curve.png'))
+        logger.log('info', 'Created plot of MAE vs. descriptors', 'WORKFLOW')
+
+    # Tune ANN hyperparameters according to validation set performance
+    logger.log('info', 'Tuning ANN hyperparameters...', 'WORKFLOW')
+    config = default_config()
+    config = tune_hyperparameters(df, config, 25, 10, num_processes,
+                                  eval_set='valid', eval_fn='med_abs_error',
+                                  epochs=300, validate=False)
+    config['epochs'] = default_config()['epochs']
+    config_filename = db_name.replace('.csv', '.yml')
+    save_config(config, config_filename)
+    logger.log('info', 'Tuned ANN hyperparameters', 'WORKFLOW')
+    logger.log('info', '\tLearning rate: {}'.format(config['learning_rate']),
+               'WORKFLOW')
+    logger.log('info', '\tLR decay: {}'.format(config['decay']), 'WORKFLOW')
+    logger.log('info', '\tHidden layers: {}'.format(config['hidden_layers']),
+               'WORKFLOW')
+
+    # Create Model
+    logger.log('info', 'Generating ANN...', 'WORKFLOW')
+    df.create_sets()
+    sets = df.package_sets()
+    _ = train_model(sets, config, None, 'rmse', False,
+                    db_name.replace('.csv', '.h5'), True, True)
+    logger.log('info', 'Generated ANN', 'WORKFLOW')
+
+    logger.log('info', 'Measuring ANN performance...', 'WORKFLOW')
+    preds_learn = use_model(sets, 'learn', db_name.replace('.csv', '.h5'))
+    preds_valid = use_model(sets, 'valid', db_name.replace('.csv', '.h5'))
+    preds_test = use_model(sets, 'test', db_name.replace('.csv', '.h5'))
+    learn_mae = calc_med_abs_error(preds_learn, sets.learn_y)
+    learn_r2 = calc_r2(preds_learn, sets.learn_y)
+    valid_mae = calc_med_abs_error(preds_valid, sets.valid_y)
+    valid_r2 = calc_r2(preds_valid, sets.valid_y)
+    test_mae = calc_med_abs_error(preds_test, sets.test_y)
+    test_r2 = calc_r2(preds_test, sets.test_y)
+    logger.log('info', 'Measured ANN performance', 'WORKFLOW')
+    logger.log('info', '\tLearning set:\t R2: {}\t MAE: {}'.format(
+        learn_r2, learn_mae), 'WORKFLOW')
+    logger.log('info', '\tValidation set:\t R2: {}\t MAE: {}'.format(
+        valid_r2, valid_mae), 'WORKFLOW')
+    logger.log('info', '\tTesting set:\t R2: {}\t MAE: {}'.format(
+        test_r2, test_mae), 'WORKFLOW')
+
+    if create_plots:
+        logger.log('info', 'Creating parity plot...', 'WORKFLOW')
+        plt.clf()
+        parity_plot = ParityPlot(
+            '{} Parity Plot'.format(prop_abvr),
+            'Experimental {} Value'.format(prop_abvr),
+            'Predicted {} Value'.format(prop_abvr)
+        )
+        parity_plot.add_series(sets.learn_y, preds_learn, 'Learning Set',
+                               'blue')
+        parity_plot.add_series(sets.valid_y, preds_valid, 'Validation Set',
+                               'green')
+        parity_plot.add_series(sets.test_y, preds_test, 'Test Set', 'red')
+        parity_plot.add_error_bars(test_mae, 'Test MAE')
+        parity_plot._add_label('Test $R^2$', test_r2)
+        parity_plot._add_label('Validation MAE', valid_mae)
+        parity_plot._add_label('Validation $R^2$', valid_r2)
+        parity_plot._add_label('Learning MAE', learn_mae)
+        parity_plot._add_label('Learning $R^2$', learn_r2)
+        parity_plot.save(db_name.replace('.csv', '_parity.png'))
+        logger.log('info', 'Created parity plot', 'WORKFLOW')
+
+
+if __name__ == '__main__':
+
+    create_model('CN', db_name='cn_database_v1.0.csv', num_processes=4)

--- a/ecnet/workflows/ecrl_workflow.py
+++ b/ecnet/workflows/ecrl_workflow.py
@@ -6,9 +6,8 @@ from ecnet.utils.error_utils import calc_med_abs_error, calc_r2
 from ecnet.utils.logging import logger
 from ecnet.utils.server_utils import default_config, save_config, train_model,\
     use_model
-from workflow_utils import find_optimal_num_inputs, prop_range_from_split
-# from ecnet.workflows.workflow_utils import find_optimal_num_inputs,\
-#     prop_range_from_split
+from ecnet.workflows.workflow_utils import find_optimal_num_inputs,\
+    prop_range_from_split
 
 from datetime import datetime
 
@@ -159,8 +158,3 @@ def create_model(prop_abvr: str, smiles: list=None, targets: list=None,
         parity_plot._add_label('Learning $R^2$', learn_r2)
         parity_plot.save(db_name.replace('.csv', '_parity.png'))
         logger.log('info', 'Created parity plot', 'WORKFLOW')
-
-
-if __name__ == '__main__':
-
-    create_model('CN', db_name='cn_database_v1.0.csv', num_processes=4)

--- a/ecnet/workflows/ecrl_workflow.py
+++ b/ecnet/workflows/ecrl_workflow.py
@@ -116,13 +116,13 @@ def create_model(prop_abvr: str, smiles: list=None, targets: list=None,
     df.create_sets()
     sets = df.package_sets()
     _ = train_model(sets, config, None, 'rmse', False,
-                    db_name.replace('.csv', '.h5'), True, True)
+                    db_name.replace('.csv', '.ecnet'), True, True)
     logger.log('info', 'Generated ANN', 'WORKFLOW')
 
     logger.log('info', 'Measuring ANN performance...', 'WORKFLOW')
-    preds_learn = use_model(sets, 'learn', db_name.replace('.csv', '.h5'))
-    preds_valid = use_model(sets, 'valid', db_name.replace('.csv', '.h5'))
-    preds_test = use_model(sets, 'test', db_name.replace('.csv', '.h5'))
+    preds_learn = use_model(sets, 'learn', db_name.replace('.csv', '.ecnet'))
+    preds_valid = use_model(sets, 'valid', db_name.replace('.csv', '.ecnet'))
+    preds_test = use_model(sets, 'test', db_name.replace('.csv', '.ecnet'))
     learn_mae = calc_med_abs_error(preds_learn, sets.learn_y)
     learn_r2 = calc_r2(preds_learn, sets.learn_y)
     valid_mae = calc_med_abs_error(preds_valid, sets.valid_y)

--- a/ecnet/workflows/ecrl_workflow.py
+++ b/ecnet/workflows/ecrl_workflow.py
@@ -1,25 +1,37 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# ecnet/workflows/ecrl_workflow.py
+# v.3.3.0
+# Developed in 2020 by Travis Kessler <travis.j.kessler@gmail.com>
+#
+# General workflow used by the UMass Lowell Energy and Combustion Research
+# Laboratory
+#
+
+# Stdlib imports
+from datetime import datetime
+
+# 3rd party imports
+from matplotlib import pyplot as plt
+
+# ECNet imports
 from ecnet import Server
 from ecnet.tasks.tuning import tune_hyperparameters
 from ecnet.tools.database import create_db
 from ecnet.tools.plotting import ParityPlot
 from ecnet.utils.data_utils import DataFrame
-from ecnet.utils.error_utils import calc_med_abs_error, calc_r2
 from ecnet.utils.logging import logger
-from ecnet.utils.server_utils import default_config, save_config, train_model,\
-    use_model
+from ecnet.utils.server_utils import default_config, save_config
 from ecnet.workflows.workflow_utils import find_optimal_num_inputs,\
     prop_range_from_split
 
-from datetime import datetime
 
-from matplotlib import pyplot as plt
-
-
-def create_model(prop_abvr: str, smiles: list=None, targets: list=None,
-                 db_name: str=None, qspr_backend: str='padel',
-                 create_plots: bool=True, data_split: list=[0.7, 0.2, 0.1],
-                 log_level: str='info', log_to_file: bool=True,
-                 num_processes: int=1):
+def create_model(prop_abvr: str, smiles: list = None, targets: list = None,
+                 db_name: str = None, qspr_backend: str = 'padel',
+                 create_plots: bool = True, data_split: list = [0.7, 0.2, 0.1],
+                 log_level: str = 'info', log_to_file: bool = True,
+                 num_processes: int = 1):
     ''' create_model: ECRL's database/model creation workflow for all
     publications
 

--- a/ecnet/workflows/workflow_utils.py
+++ b/ecnet/workflows/workflow_utils.py
@@ -59,6 +59,7 @@ def find_optimal_num_inputs(db_name: str, eval_set: str,
     conf['epochs'] = 300
     df = DataFrame(db_name)
     df.create_sets()
+    conf['batch_size'] = len(df.learn_set)
     desc = limit_rforest(df, len(df._input_names), num_processes=num_processes,
                          eval_set=eval_set)
     desc = [d[0] for d in desc]

--- a/ecnet/workflows/workflow_utils.py
+++ b/ecnet/workflows/workflow_utils.py
@@ -90,13 +90,13 @@ def find_optimal_num_inputs(db_name: str, eval_set: str,
             errors.append([d_idx, train_model(
                 sets, conf, eval_set, 'med_abs_error', False, '_.ecnet',
                 False, False
-            )])
+            )[0]])
 
     if num_processes > 1:
         train_pool.close()
         train_pool.join()
         for idx, err in enumerate(errors):
-            errors[idx][1] = err[1].get()
+            errors[idx][1] = err[1].get()[0]
 
     min_error = errors[0][1]
     opt_num_desc = 1

--- a/ecnet/workflows/workflow_utils.py
+++ b/ecnet/workflows/workflow_utils.py
@@ -1,0 +1,108 @@
+from ecnet.utils.data_utils import DataFrame
+from ecnet.utils.server_utils import default_config, train_model
+from ecnet.tasks.limit_inputs import limit_rforest
+
+from multiprocessing import Pool, set_start_method
+from os import name
+
+
+def prop_range_from_split(db_name: str, data_split: list):
+    ''' prop_range_from_split: creates learning, validation, test subsets, each
+    with proportionally equal number of compounds based on experimental value
+    range
+
+    Args:
+        db_name (str): name/location of ECNet-formatted database
+        data_split (list): [learn %, valid %, test %] for all supplied data
+    '''
+
+    df = DataFrame(db_name)
+    for mol in df.data_points:
+        mol.assignment = 'L'
+        mol.TARGET = float(mol.TARGET)
+    df.data_points = sorted(df.data_points, key=lambda m: m.TARGET,
+                            reverse=True)
+    num_validate = int(len(df) / (data_split[1] * len(df.data_points)))
+    num_test = int(len(df) / (data_split[2] * len(df.data_points)))
+    for idx, mol in enumerate(df.data_points):
+        if (idx + 1) % num_validate == 0:
+            mol.assignment = 'V'
+        if (idx + 3) % num_test == 0:
+            mol.assignment = 'T'
+    if len([m for m in df.data_points if m.assignment == 'V']) == 0:
+        raise ValueError('Data split resulted in empty validation set')
+    if len([m for m in df.data_points if m.assignment == 'T']) == 0:
+        raise ValueError('Data split resulted in empty test set')
+    df.data_points = sorted(df.data_points, key=lambda m: m.id)
+    df.save(db_name)
+
+
+def find_optimal_num_inputs(db_name: str, eval_set: str,
+                            num_processes: int) -> tuple:
+    ''' find_optimal_num_inputs: find the optimal number of input variables,
+    return names of variables; optimal number of variables produces lowest
+    median absolute error; variables added 25 at a time, according to RFR
+    importance score (most-to-least important)
+
+    Args:
+        db_name (str): name/location of ECNet-formatted database
+        eval_set (str): set to evaluate (`learn`, `valid`, `train`, `test`,
+            None (all))
+        num_processes (int): number of concurrent processes to run for RFR,
+            training
+
+    Returns:
+        tuple: ([addition1, error1, ..., additionN, errorN], opt_desc)
+    '''
+
+    conf = default_config()
+    conf['epochs'] = 300
+    df = DataFrame(db_name)
+    df.create_sets()
+    desc = limit_rforest(df, len(df._input_names), num_processes=num_processes,
+                         eval_set=eval_set)
+    desc = [d[0] for d in desc]
+
+    errors = []
+    if num_processes > 1:
+        if name != 'nt':
+            set_start_method('spawn', force=True)
+        train_pool = Pool(processes=num_processes)
+
+    for d_idx in range(0, len(desc), 10):
+        if d_idx >= len(desc) - 1:
+            to_use = desc[:]
+        else:
+            to_use = desc[: d_idx + 1]
+        df = DataFrame(db_name)
+        df.set_inputs(to_use)
+        df.create_sets()
+        sets = df.package_sets()
+
+        if num_processes > 1:
+            errors.append([d_idx, train_pool.apply_async(
+                train_model, [
+                    sets, conf, eval_set, 'med_abs_error', False, '_.h5',
+                    False, False
+                ]
+            )])
+        else:
+            errors.append([d_idx, train_model(
+                sets, conf, eval_set, 'med_abs_error', False, '_.h5',
+                False, False
+            )])
+
+    if num_processes > 1:
+        train_pool.close()
+        train_pool.join()
+        for idx, err in enumerate(errors):
+            errors[idx][1] = err[1].get()
+
+    min_error = errors[0][1]
+    opt_num_desc = 1
+    for err in errors[1:]:
+        if err[1] < min_error:
+            min_error = err[1]
+            opt_num_desc = err[0]
+
+    return (errors, desc[: opt_num_desc])

--- a/ecnet/workflows/workflow_utils.py
+++ b/ecnet/workflows/workflow_utils.py
@@ -82,13 +82,13 @@ def find_optimal_num_inputs(db_name: str, eval_set: str,
         if num_processes > 1:
             errors.append([d_idx, train_pool.apply_async(
                 train_model, [
-                    sets, conf, eval_set, 'med_abs_error', False, '_.h5',
+                    sets, conf, eval_set, 'med_abs_error', False, '_.ecnet',
                     False, False
                 ]
             )])
         else:
             errors.append([d_idx, train_model(
-                sets, conf, eval_set, 'med_abs_error', False, '_.h5',
+                sets, conf, eval_set, 'med_abs_error', False, '_.ecnet',
                 False, False
             )])
 

--- a/ecnet/workflows/workflow_utils.py
+++ b/ecnet/workflows/workflow_utils.py
@@ -1,9 +1,21 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# ecnet/workflows/workflow_utils.py
+# v.3.3.0
+# Developed in 2020 by Travis Kessler <travis.j.kessler@gmail.com>
+#
+# Functions used by the ECRL workflow
+#
+
+# Stdlib imports
+from multiprocessing import Pool, set_start_method
+from os import name
+
+# ECNet imports
 from ecnet.utils.data_utils import DataFrame
 from ecnet.utils.server_utils import default_config, train_model
 from ecnet.tasks.limit_inputs import limit_rforest
-
-from multiprocessing import Pool, set_start_method
-from os import name
 
 
 def prop_range_from_split(db_name: str, data_split: list):

--- a/ecnet/workflows/workflow_utils.py
+++ b/ecnet/workflows/workflow_utils.py
@@ -83,13 +83,13 @@ def find_optimal_num_inputs(db_name: str, eval_set: str,
         if num_processes > 1:
             errors.append([d_idx, train_pool.apply_async(
                 train_model, [
-                    sets, conf, eval_set, 'med_abs_error', False, '_.ecnet',
+                    sets, conf, eval_set, 'med_abs_error', False, '_.h5',
                     False, False
                 ]
             )])
         else:
             errors.append([d_idx, train_model(
-                sets, conf, eval_set, 'med_abs_error', False, '_.ecnet',
+                sets, conf, eval_set, 'med_abs_error', False, '_.h5',
                 False, False
             )[0]])
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ else:
 
 setup(
     name='ecnet',
-    version='3.2.3',
+    version='3.3.0',
     description='UMass Lowell Energy and Combustion Research Laboratory Neural'
                 ' Network Software',
     url='https://github.com/ecrl/ecnet',

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,4 @@
 from setuptools import setup, find_packages
-from platform import system, mac_ver
-
-install_requires = [
-    'torch',
-    'alvadescpy==0.1.0',
-    'colorlogging==0.3.5',
-    'ecabc==2.2.3',
-    'matplotlib==3.1.2',
-    'numpy==1.16.4',
-    'padelpy==0.1.6',
-    'pyyaml==5.1.1',
-    'scikit-learn==0.21.2'
-]
-
-s = system()
-if s == 'Windows':
-    dependency_links = ['https://download.pytorch.org/whl/cpu/torch-1.3.1%2Bcpu-cp37-cp37m-win_amd64.whl']
-elif s == 'Linux':
-    if mac_ver()[0] != '':
-        dependency_links = ['https://download.pytorch.org/whl/cpu/torch-1.3.1-cp37-none-macosx_10_7_x86_64.whl']
-    else:
-        dependency_links = ['https://download.pytorch.org/whl/cpu/torch-1.3.1%2Bcpu-cp37-cp37m-linux_x86_64.whl']
-else:
-    raise OSError('Unsupported OS: {}'.format(s))
 
 setup(
     name='ecnet',
@@ -36,7 +12,17 @@ setup(
     license='MIT',
     packages=find_packages(),
     python_requires='~=3.7',
-    install_requires=install_requires,
-    dependency_links=dependency_links,
+    install_requires=[
+        'alvadescpy==0.1.0',
+        'colorlogging==0.3.5',
+        'ecabc==2.2.3',
+        'keras==2.3.1',
+        'matplotlib==3.1.2',
+        'numpy==1.16.4',
+        'padelpy==0.1.6',
+        'pyyaml==5.1.1',
+        'scikit-learn==0.21.2',
+        'tensorflow==1.15.0'
+    ],
     zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,33 @@
 from setuptools import setup, find_packages
+from platform import system, mac_ver
+
+install_requires = [
+    'alvadescpy==0.1.0',
+    'colorlogging==0.3.5',
+    'ecabc==2.2.3',
+    'matplotlib==3.1.2',
+    'numpy==1.16.4',
+    'padelpy==0.1.6',
+    'pyyaml==5.1.1',
+    'scikit-learn==0.21.2'
+]
+
+s = system()
+if s == 'Windows':
+    install_requires.append(
+        'torch @ https://download.pytorch.org/whl/cpu/torch-1.3.1%2Bcpu-cp37-cp37m-win_amd64.whl'
+    )
+elif s == 'Linux':
+    if mac_ver()[0] != '':
+        install_requires.append(
+            'torch @ https://download.pytorch.org/whl/cpu/torch-1.3.1-cp37-none-macosx_10_7_x86_64.whl'
+        )
+    else:
+        install_requires.append(
+            'torch @ https://download.pytorch.org/whl/cpu/torch-1.3.1%2Bcpu-cp37-cp37m-linux_x86_64.whl'
+        )
+else:
+    raise OSError('Unsupported OS: {}'.format(s))
 
 setup(
     name='ecnet',
@@ -11,17 +40,7 @@ setup(
                  ' Hunter_Mack@uml.edu',
     license='MIT',
     packages=find_packages(),
-    install_requires=[
-        'alvadescpy==0.1.0',
-        'colorlogging==0.3.5',
-        'ecabc==2.2.3',
-        'keras==2.2.4',
-        'matplotlib==3.1.0',
-        'numpy==1.16.4',
-        'padelpy==0.1.6',
-        'pyyaml==5.1.1',
-        'scikit-learn==0.21.2',
-        'tensorflow==1.13.1'
-    ],
+    python_requires='~=3.7',
+    install_requires=install_requires,
     zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ install_requires = [
     'alvadescpy==0.1.0',
     'colorlogging==0.3.5',
     'ecabc==2.2.3',
-    'keras==2.3.1',
     'matplotlib==3.1.2',
     'numpy==1.16.4',
     'padelpy==0.1.6',
@@ -16,7 +15,7 @@ install_requires = [
 if '--omit_tf' in argv:
     argv.remove('--omit_tf')
 else:
-    install_requires.append('tensorflow==1.15.0')
+    install_requires.append('tensorflow==2.0.0')
 
 setup(
     name='ecnet',

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,10 @@ setup(
     version='3.2.3',
     description='UMass Lowell Energy and Combustion Research Laboratory Neural'
                 ' Network Software',
-    url='http://github.com/tjkessler/ecnet',
-    author='Travis Kessler, Hernan Gelaf-Romer, Sanskriti Sharma',
-    author_email='travis.j.kessler@gmail.com,'
-                 ' Hernan_Gelafromer@student.uml.edu,'
-                 ' Sanskriti_Sharma@student.uml.edu',
+    url='https://github.com/ecrl/ecnet',
+    author='Travis Kessler, John Hunter Mack',
+    author_email='Travis_Kessler@student.uml.edu,'
+                 ' Hunter_Mack@uml.edu',
     license='MIT',
     packages=find_packages(),
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup, find_packages
 from platform import system, mac_ver
 
 install_requires = [
+    'torch',
     'alvadescpy==0.1.0',
     'colorlogging==0.3.5',
     'ecabc==2.2.3',
@@ -14,18 +15,12 @@ install_requires = [
 
 s = system()
 if s == 'Windows':
-    install_requires.append(
-        'torch @ https://download.pytorch.org/whl/cpu/torch-1.3.1%2Bcpu-cp37-cp37m-win_amd64.whl'
-    )
+    dependency_links = ['https://download.pytorch.org/whl/cpu/torch-1.3.1%2Bcpu-cp37-cp37m-win_amd64.whl']
 elif s == 'Linux':
     if mac_ver()[0] != '':
-        install_requires.append(
-            'torch @ https://download.pytorch.org/whl/cpu/torch-1.3.1-cp37-none-macosx_10_7_x86_64.whl'
-        )
+        dependency_links = ['https://download.pytorch.org/whl/cpu/torch-1.3.1-cp37-none-macosx_10_7_x86_64.whl']
     else:
-        install_requires.append(
-            'torch @ https://download.pytorch.org/whl/cpu/torch-1.3.1%2Bcpu-cp37-cp37m-linux_x86_64.whl'
-        )
+        dependency_links = ['https://download.pytorch.org/whl/cpu/torch-1.3.1%2Bcpu-cp37-cp37m-linux_x86_64.whl']
 else:
     raise OSError('Unsupported OS: {}'.format(s))
 
@@ -42,5 +37,6 @@ setup(
     packages=find_packages(),
     python_requires='~=3.7',
     install_requires=install_requires,
+    dependency_links=dependency_links,
     zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,22 @@
 from setuptools import setup, find_packages
+from sys import argv
+
+install_requires = [
+    'alvadescpy==0.1.0',
+    'colorlogging==0.3.5',
+    'ecabc==2.2.3',
+    'keras==2.3.1',
+    'matplotlib==3.1.2',
+    'numpy==1.16.4',
+    'padelpy==0.1.6',
+    'pyyaml==5.1.1',
+    'scikit-learn==0.21.2'
+]
+
+if '--omit_tf' in argv:
+    argv.remove('--omit_tf')
+else:
+    install_requires.append('tensorflow==1.15.0')
 
 setup(
     name='ecnet',
@@ -12,17 +30,6 @@ setup(
     license='MIT',
     packages=find_packages(),
     python_requires='~=3.7',
-    install_requires=[
-        'alvadescpy==0.1.0',
-        'colorlogging==0.3.5',
-        'ecabc==2.2.3',
-        'keras==2.3.1',
-        'matplotlib==3.1.2',
-        'numpy==1.16.4',
-        'padelpy==0.1.6',
-        'pyyaml==5.1.1',
-        'scikit-learn==0.21.2',
-        'tensorflow==1.15.0'
-    ],
+    install_requires=install_requires,
     zip_safe=False
 )

--- a/tests/models/test_mlp.py
+++ b/tests/models/test_mlp.py
@@ -27,7 +27,7 @@ class TestMLP(unittest.TestCase):
         results = mlp_saved.use(array([[1, 1, 1], [0, 0, 0]]))
         self.assertAlmostEqual(results[0][0], 1, 3)
         self.assertAlmostEqual(results[1][0], 0, 3)
-        remove('model.ecnet')
+        remove('model.h5')
 
 
 if __name__ == '__main__':

--- a/tests/models/test_mlp.py
+++ b/tests/models/test_mlp.py
@@ -27,7 +27,7 @@ class TestMLP(unittest.TestCase):
         results = mlp_saved.use(array([[1, 1, 1], [0, 0, 0]]))
         self.assertAlmostEqual(results[0][0], 1, 3)
         self.assertAlmostEqual(results[1][0], 0, 3)
-        remove('model.h5')
+        remove('model.ecnet')
 
 
 if __name__ == '__main__':

--- a/tests/models/test_mlp.py
+++ b/tests/models/test_mlp.py
@@ -15,7 +15,8 @@ class TestMLP(unittest.TestCase):
         mlp.add_layer(9, 'relu', 3)
         mlp.add_layer(6, 'relu')
         mlp.add_layer(1, 'linear')
-        mlp.fit(array([[1, 1, 1], [0, 0, 0]]), array([[1], [0]]), epochs=20000)
+        mlp.fit(array([[1, 1, 1], [0, 0, 0]]), array([[1], [0]]), epochs=2000,
+                lr=0.01)
 
         results = mlp.use(array([[1, 1, 1], [0, 0, 0]]))
         self.assertAlmostEqual(results[0][0], 1, 3)

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -58,14 +58,14 @@ class TestServer(unittest.TestCase):
             self.assertTrue(exists(join(
                 'test_project',
                 'pool_{}'.format(pool),
-                'model.h5'
+                'model.ecnet'
             )))
             for candidate in range(2):
                 self.assertTrue(exists(join(
                     'test_project',
                     'pool_{}'.format(pool),
                     'candidate_{}'.format(candidate),
-                    'model.h5'
+                    'model.ecnet'
                 )))
         remove('config.yml')
         rmtree('test_project')
@@ -109,14 +109,14 @@ class TestServer(unittest.TestCase):
             self.assertTrue(exists(join(
                 'test_project',
                 'pool_{}'.format(pool),
-                'model.h5'
+                'model.ecnet'
             )))
             for candidate in range(4):
                 self.assertTrue(exists(join(
                     'test_project',
                     'pool_{}'.format(pool),
                     'candidate_{}'.format(candidate),
-                    'model.h5'
+                    'model.ecnet'
                 )))
         remove('config.yml')
         rmtree('test_project')

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -58,14 +58,14 @@ class TestServer(unittest.TestCase):
             self.assertTrue(exists(join(
                 'test_project',
                 'pool_{}'.format(pool),
-                'model.ecnet'
+                'model.h5'
             )))
             for candidate in range(2):
                 self.assertTrue(exists(join(
                     'test_project',
                     'pool_{}'.format(pool),
                     'candidate_{}'.format(candidate),
-                    'model.ecnet'
+                    'model.h5'
                 )))
         remove('config.yml')
         rmtree('test_project')
@@ -109,14 +109,14 @@ class TestServer(unittest.TestCase):
             self.assertTrue(exists(join(
                 'test_project',
                 'pool_{}'.format(pool),
-                'model.ecnet'
+                'model.h5'
             )))
             for candidate in range(4):
                 self.assertTrue(exists(join(
                     'test_project',
                     'pool_{}'.format(pool),
                     'candidate_{}'.format(candidate),
-                    'model.ecnet'
+                    'model.h5'
                 )))
         remove('config.yml')
         rmtree('test_project')

--- a/tests/tasks/test_limit_inputs.py
+++ b/tests/tasks/test_limit_inputs.py
@@ -23,6 +23,38 @@ class TestLimit(unittest.TestCase):
         df.set_inputs([r[0] for r in result])
         self.assertEqual(len(df._input_names), 2)
 
+    def test_limit_sets(self):
+
+        print('\nUNIT TEST: limit_sets')
+        df = DataFrame(DB_LOC)
+        df.create_sets()
+        result = limit_rforest(df, 2, eval_set='valid')
+        self.assertEqual(len(result), 2)
+        self.assertEqual(len(result[0]), 2)
+        df.set_inputs([r[0] for r in result])
+        self.assertEqual(len(df._input_names), 2)
+        df = DataFrame(DB_LOC)
+        df.create_sets()
+        result = limit_rforest(df, 2, eval_set='train')
+        self.assertEqual(len(result), 2)
+        self.assertEqual(len(result[0]), 2)
+        df.set_inputs([r[0] for r in result])
+        self.assertEqual(len(df._input_names), 2)
+        df = DataFrame(DB_LOC)
+        df.create_sets()
+        result = limit_rforest(df, 2, eval_set='test')
+        self.assertEqual(len(result), 2)
+        self.assertEqual(len(result[0]), 2)
+        df.set_inputs([r[0] for r in result])
+        self.assertEqual(len(df._input_names), 2)
+        df = DataFrame(DB_LOC)
+        df.create_sets()
+        result = limit_rforest(df, 2, eval_set=None)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(len(result[0]), 2)
+        df.set_inputs([r[0] for r in result])
+        self.assertEqual(len(df._input_names), 2)
+
     def test_server_limit(self):
 
         print('\nUNIT TEST: limit_rforest (Server)')

--- a/tests/utils/test_server_utils.py
+++ b/tests/utils/test_server_utils.py
@@ -30,10 +30,10 @@ class TestServerUtils(unittest.TestCase):
         self.assertEqual(
             dc, {
                 'epochs': 3000,
-                'learning_rate': 0.001,
+                'learning_rate': 0.01,
                 'beta_1': 0.9,
                 'beta_2': 0.999,
-                'epsilon': 0.0000001,
+                'epsilon': 1e-8,
                 'decay': 0.0,
                 'hidden_layers': [
                     [32, 'relu'],
@@ -56,12 +56,12 @@ class TestServerUtils(unittest.TestCase):
         )
         self.assertEqual(
             server_utils.get_candidate_path(prj_name, pool, candidate, True),
-            join('test_project', 'pool_1', 'candidate_2', 'model.h5')
+            join('test_project', 'pool_1', 'candidate_2', 'model.ecnet')
         )
         self.assertEqual(
             server_utils.get_candidate_path(prj_name, pool, candidate,
                                             p_best=True),
-            join('test_project', 'pool_1', 'model.h5')
+            join('test_project', 'pool_1', 'model.ecnet')
         )
 
     def test_get_error(self):
@@ -126,10 +126,10 @@ class TestServerUtils(unittest.TestCase):
             server_utils.open_config('config.yml'),
             {
                 'epochs': 3000,
-                'learning_rate': 0.001,
+                'learning_rate': 0.01,
                 'beta_1': 0.9,
                 'beta_2': 0.999,
-                'epsilon': 0.0000001,
+                'epsilon': 1e-8,
                 'decay': 0.0,
                 'hidden_layers': [
                     [32, 'relu'],
@@ -163,10 +163,10 @@ class TestServerUtils(unittest.TestCase):
         config = server_utils.default_config()
         config['epochs'] = 100
         r_squared = server_utils.train_model(
-            pd, config, 'test', 'r2', filename='test_train.h5'
+            pd, config, 'test', 'r2', filename='test_train.ecnet'
         )
-        self.assertTrue(exists('test_train.h5'))
-        remove('test_train.h5')
+        self.assertTrue(exists('test_train.ecnet'))
+        remove('test_train.ecnet')
 
     def test_use_model(self):
 
@@ -177,29 +177,29 @@ class TestServerUtils(unittest.TestCase):
         config = server_utils.default_config()
         config['epochs'] = 100
         _ = server_utils.train_model(
-            pd, config, 'test', 'rmse', filename='test_use.h5'
+            pd, config, 'test', 'rmse', filename='test_use.ecnet'
         )
         self.assertEqual(
-            len(server_utils.use_model(pd, 'learn', 'test_use.h5')),
+            len(server_utils.use_model(pd, 'learn', 'test_use.ecnet')),
             len(pd.learn_y)
         )
         self.assertEqual(
-            len(server_utils.use_model(pd, 'valid', 'test_use.h5')),
+            len(server_utils.use_model(pd, 'valid', 'test_use.ecnet')),
             len(pd.valid_y)
         )
         self.assertEqual(
-            len(server_utils.use_model(pd, 'test', 'test_use.h5')),
+            len(server_utils.use_model(pd, 'test', 'test_use.ecnet')),
             len(pd.test_y)
         )
         self.assertEqual(
-            len(server_utils.use_model(pd, 'train', 'test_use.h5')),
+            len(server_utils.use_model(pd, 'train', 'test_use.ecnet')),
             len(pd.learn_y) + len(pd.valid_y)
         )
         self.assertEqual(
-            len(server_utils.use_model(pd, None, 'test_use.h5')),
+            len(server_utils.use_model(pd, None, 'test_use.ecnet')),
             len(pd.learn_y) + len(pd.valid_y) + len(pd.test_y)
         )
-        remove('test_use.h5')
+        remove('test_use.ecnet')
 
 
 if __name__ == '__main__':

--- a/tests/utils/test_server_utils.py
+++ b/tests/utils/test_server_utils.py
@@ -40,7 +40,8 @@ class TestServerUtils(unittest.TestCase):
                     [32, 'relu']
                 ],
                 'output_activation': 'linear',
-                'batch_size': 32
+                'batch_size': 32,
+                'patience': 128
             }
         )
 
@@ -136,7 +137,8 @@ class TestServerUtils(unittest.TestCase):
                     [32, 'relu']
                 ],
                 'output_activation': 'linear',
-                'batch_size': 32
+                'batch_size': 32,
+                'patience': 128
             }
         )
         remove('config.yml')
@@ -162,7 +164,7 @@ class TestServerUtils(unittest.TestCase):
         pd = df.package_sets()
         config = server_utils.default_config()
         config['epochs'] = 100
-        r_squared = server_utils.train_model(
+        _ = server_utils.train_model(
             pd, config, 'test', 'r2', filename='test_train.ecnet'
         )
         self.assertTrue(exists('test_train.ecnet'))

--- a/tests/utils/test_server_utils.py
+++ b/tests/utils/test_server_utils.py
@@ -57,12 +57,12 @@ class TestServerUtils(unittest.TestCase):
         )
         self.assertEqual(
             server_utils.get_candidate_path(prj_name, pool, candidate, True),
-            join('test_project', 'pool_1', 'candidate_2', 'model.ecnet')
+            join('test_project', 'pool_1', 'candidate_2', 'model.h5')
         )
         self.assertEqual(
             server_utils.get_candidate_path(prj_name, pool, candidate,
                                             p_best=True),
-            join('test_project', 'pool_1', 'model.ecnet')
+            join('test_project', 'pool_1', 'model.h5')
         )
 
     def test_get_error(self):
@@ -165,10 +165,10 @@ class TestServerUtils(unittest.TestCase):
         config = server_utils.default_config()
         config['epochs'] = 100
         _ = server_utils.train_model(
-            pd, config, 'test', 'r2', filename='test_train.ecnet'
+            pd, config, 'test', 'r2', filename='test_train.h5'
         )
-        self.assertTrue(exists('test_train.ecnet'))
-        remove('test_train.ecnet')
+        self.assertTrue(exists('test_train.h5'))
+        remove('test_train.h5')
 
     def test_use_model(self):
 
@@ -179,29 +179,29 @@ class TestServerUtils(unittest.TestCase):
         config = server_utils.default_config()
         config['epochs'] = 100
         _ = server_utils.train_model(
-            pd, config, 'test', 'rmse', filename='test_use.ecnet'
+            pd, config, 'test', 'rmse', filename='test_use.h5'
         )
         self.assertEqual(
-            len(server_utils.use_model(pd, 'learn', 'test_use.ecnet')),
+            len(server_utils.use_model(pd, 'learn', 'test_use.h5')),
             len(pd.learn_y)
         )
         self.assertEqual(
-            len(server_utils.use_model(pd, 'valid', 'test_use.ecnet')),
+            len(server_utils.use_model(pd, 'valid', 'test_use.h5')),
             len(pd.valid_y)
         )
         self.assertEqual(
-            len(server_utils.use_model(pd, 'test', 'test_use.ecnet')),
+            len(server_utils.use_model(pd, 'test', 'test_use.h5')),
             len(pd.test_y)
         )
         self.assertEqual(
-            len(server_utils.use_model(pd, 'train', 'test_use.ecnet')),
+            len(server_utils.use_model(pd, 'train', 'test_use.h5')),
             len(pd.learn_y) + len(pd.valid_y)
         )
         self.assertEqual(
-            len(server_utils.use_model(pd, None, 'test_use.ecnet')),
+            len(server_utils.use_model(pd, None, 'test_use.h5')),
             len(pd.learn_y) + len(pd.valid_y) + len(pd.test_y)
         )
-        remove('test_use.ecnet')
+        remove('test_use.h5')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Addition of validated, PaDEL/alvaDesc-generated YSI databases
- Update to repository links, author information
- ecnet.utils.data_utils now forces UTF-8 encoding for all database creation/saving
- ML back-end updated to TensorFlow 2.0.0
    - No API changes to _ecnet.models.mlp.MultilayerPerceptron_
    - Existing .h5 model files **will not work** with the updated class

     _**Note:** initially, PyTorch was looked at as an alternative; however, after tests to evaluate performance were conducted and the viability of installing PyTorch on high-performance machines available to the ECRL were both deemed inadequate, updating to TensorFlow 2.0.0 was deemed the most appropriate action._
- Only the following hyper-parameters are tuned with the built-in functions:
    - **Learning rate** of Adam optimization function
    - **Learning rate decay** of Adam optimization function
    - **Batch size** during training
    - **Patience** (if validating, # epochs to wait for better validation loss, else terminate training)
    - **Size** of each hidden layer

    _**Note:** with the relatively small number of samples our models are trained with, it does not make sense to adjust hyper-parameters such as **beta_1**, **beta_2**, and **epsilon**. The hyper-parameters listed above are theorized to play a much more important role with how the models train/perform._
- Added the UML ECRL's general publication workflow as _ecnet.workflows.ecrl_workflow.create_model_
- If using _ecnet.Server_ and not creating a project, a single model's filename can now be specified as an additional argument (default: _model.h5_)
- TensorFlow's _verbose_ argument is now propagated from _ecnet.Server.train_ to the model during training; added as an additional argument
- _ecnet.models.mlp.MultilayerPerceptron.fit_ now returns a tuple: _(learn losses, validation losses)_; _learn losses_ and _validation losses_ are both lists containing loss values (mean squared error) at every epoch; if training a single model using _ecnet.Server.train_, this tuple is returned; if not performing validation, the _validation losses_ list is populated with _None_ elements equal in size to the _learn losses_ list
- If installing using _setup.py_, installing TensorFlow is optional; to skip the installation of the pre-compiled PyPI distribution of TensorFlow, run _setup.py_ with **python setup.py --omit_tf install**

    _**Note:** other methods of installing TensorFlow offer clear benefits (GPU support, different CPU instruction sets, etc.), therefore we want to provide an option for the user to use an existing installation of TensorFlow instead of forcing the PyPI-sourced version._